### PR TITLE
Add sentiment-aware CappuccinoAgent

### DIFF
--- a/cappuccino_agent.py
+++ b/cappuccino_agent.py
@@ -1,0 +1,32 @@
+import asyncio
+
+from nltk.sentiment import SentimentIntensityAnalyzer
+
+
+class CappuccinoAgent:
+    """Simple agent that generates responses with sentiment awareness."""
+
+    def __init__(self):
+        self.sentiment = SentimentIntensityAnalyzer()
+
+    async def detect_sentiment(self, text: str) -> str:
+        """Return 'positive', 'negative', or 'neutral' sentiment for text."""
+        scores = await asyncio.to_thread(self.sentiment.polarity_scores, text)
+        compound = scores.get("compound", 0)
+        if compound >= 0.05:
+            return "positive"
+        if compound <= -0.05:
+            return "negative"
+        return "neutral"
+
+    async def generate_response(self, text: str) -> str:
+        """Generate a basic response incorporating sentiment."""
+        sentiment = await self.detect_sentiment(text)
+        if sentiment == "negative":
+            prefix = "I'm sorry to hear that. "
+        elif sentiment == "positive":
+            prefix = "That's great! "
+        else:
+            prefix = ""
+        # Placeholder for actual LLM call
+        return prefix + text

--- a/tests/test_cappuccino_agent.py
+++ b/tests/test_cappuccino_agent.py
@@ -1,0 +1,21 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import asyncio
+import pytest
+
+from cappuccino_agent import CappuccinoAgent
+
+@pytest.mark.asyncio
+async def test_detect_sentiment():
+    agent = CappuccinoAgent()
+    pos = await agent.detect_sentiment("I love this!")
+    neg = await agent.detect_sentiment("This is awful.")
+    assert pos == "positive"
+    assert neg == "negative"
+
+@pytest.mark.asyncio
+async def test_generate_response():
+    agent = CappuccinoAgent()
+    response_pos = await agent.generate_response("Great work!")
+    assert "That's great!" in response_pos
+    response_neg = await agent.generate_response("I hate everything")
+    assert "I'm sorry" in response_neg


### PR DESCRIPTION
## Summary
- implement `CappuccinoAgent` with sentiment analysis via NLTK
- generate empathetic responses based on detected sentiment
- add tests for new agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc1a6fab0832c9c9b55442ad9111b