### PR TITLE
Add planning and state management components

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -1,0 +1,19 @@
+from typing import Any, Dict, List
+
+class Planner:
+    """Generate simple multi-step plans from user context."""
+
+    def create_plan(self, context: str) -> List[Dict[str, Any]]:
+        """Create a list of steps derived from the context string.
+
+        The current implementation simply splits the context by periods and
+        returns non-empty segments as sequential steps.
+        """
+        steps = []
+        for idx, part in enumerate(context.split(".")):
+            item = part.strip()
+            if item:
+                steps.append({"step": idx + 1, "action": item})
+        if not steps:
+            steps.append({"step": 1, "action": context.strip()})
+        return steps

--- a/state_manager.py
+++ b/state_manager.py
@@ -1,0 +1,64 @@
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+import aiosqlite
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+class StateManager:
+    """Persist and manage agent state asynchronously."""
+
+    def __init__(self, db_path: str = "agent_state.db"):
+        self.db_path = db_path
+        self._conn: Optional[aiosqlite.Connection] = None
+
+    async def _get_connection(self) -> aiosqlite.Connection:
+        if self._conn is None:
+            self._conn = await aiosqlite.connect(self.db_path)
+            await self._initialize()
+        return self._conn
+
+    async def _initialize(self) -> None:
+        conn = await self._get_connection()
+        await conn.execute(
+            """CREATE TABLE IF NOT EXISTS agent_state (
+                    key TEXT PRIMARY KEY,
+                    value TEXT
+            )"""
+        )
+        await conn.commit()
+
+    async def save_plan(self, plan: List[Dict[str, Any]], current_step: int = 0) -> None:
+        """Persist plan and current step."""
+        conn = await self._get_connection()
+        await conn.execute(
+            "REPLACE INTO agent_state (key, value) VALUES (?, ?)",
+            ("task_plan", json.dumps(plan)),
+        )
+        await conn.execute(
+            "REPLACE INTO agent_state (key, value) VALUES (?, ?)",
+            ("current_step", str(current_step)),
+        )
+        await conn.commit()
+        logging.info("Agent state saved asynchronously.")
+
+    async def load_plan(self) -> Dict[str, Any]:
+        """Load plan and current step."""
+        conn = await self._get_connection()
+        cursor = await conn.execute("SELECT key, value FROM agent_state")
+        rows = await cursor.fetchall()
+        state = {row[0]: row[1] for row in rows}
+        plan = json.loads(state.get("task_plan", "[]"))
+        current_step = int(state.get("current_step", "0"))
+        logging.info("Agent state loaded asynchronously.")
+        return {"task_plan": plan, "current_step": current_step}
+
+    async def update_step(self, step: int) -> None:
+        """Update the current step."""
+        conn = await self._get_connection()
+        await conn.execute(
+            "REPLACE INTO agent_state (key, value) VALUES (?, ?)",
+            ("current_step", str(step)),
+        )
+        await conn.commit()

--- a/tests/test_planner_state.py
+++ b/tests/test_planner_state.py
@@ -1,0 +1,32 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import asyncio
+import os
+import pathlib
+
+import pytest
+
+from planner import Planner
+from state_manager import StateManager
+
+
+@pytest.mark.asyncio
+async def test_planner_and_state(tmp_path):
+    planner = Planner()
+    context = "step one. step two. step three"
+    plan = planner.create_plan(context)
+    assert len(plan) == 3
+    assert plan[0]["action"] == "step one"
+
+    db_path = tmp_path / "state.db"
+    state = StateManager(db_path=str(db_path))
+    await state.save_plan(plan, current_step=1)
+
+    loaded = await state.load_plan()
+    assert loaded["task_plan"] == plan
+    assert loaded["current_step"] == 1
+
+    await state.update_step(2)
+    loaded = await state.load_plan()
+    assert loaded["current_step"] == 2
+
+


### PR DESCRIPTION
## Summary
- implement `StateManager` to persist task plans and progress
- add `Planner` for multi-step plan generation
- test planning and state management components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc1a851dc832c892d09547a0f5eba