### PR TITLE
Add FastAPI server and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# cappuccino
+# Cappuccino
+
+Cappuccino aims to be a general‑purpose AI assistant. The project follows the design guidelines in `AGENTS.md` which emphasize high quality code, modular architecture and robust asynchronous tooling. Tools are intended to run concurrently and the API is exposed through FastAPI for easy humanoid integration.
+
+## Setup
+1. Create a Python environment (Python 3.12 or later recommended).
+2. Install dependencies:
+   ```bash
+   pip install fastapi uvicorn aiosqlite aiohttp pillow beautifulsoup4 pytest pytest-asyncio
+   ```
+
+## Running the server
+Start the FastAPI server with:
+```bash
+uvicorn main:app --reload
+```
+This runs the minimal API defined in `main.py`.
+
+## Testing
+Execute unit tests using `pytest`:
+```bash
+pytest -q
+```
+
+## Design philosophy
+Key principles from `AGENTS.md`:
+- Produce readable and maintainable Python code with proper error handling and testing【F:AGENTS.md†L80-L95】.
+- Expose the agent core through a high-performance asynchronous API using FastAPI and WebSockets【F:AGENTS.md†L1760-L1776】.
+- Ensure state management, sandbox awareness and parallel execution where appropriate【F:AGENTS.md†L1840-L1848】.
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+class UserRequest(BaseModel):
+    query: str
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+@app.post("/agent/run")
+async def run_agent(request: UserRequest):
+    # Placeholder for Cappuccino agent logic
+    return {"response": f"Processing query: {request.query}"}
+


### PR DESCRIPTION
## Summary
- document project goals, setup, FastAPI server and tests
- add a simple FastAPI `main.py` app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc1a9f4d4832cb5f17401fe294f24