### PR TITLE
Add agent class, API and unit tests

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from cappuccino_agent import CappuccinoAgent
+from tool_manager import ToolManager
+
+app = FastAPI()
+
+class UserRequest(BaseModel):
+    query: str
+
+async def default_llm(messages):
+    raise NotImplementedError("LLM not configured")
+
+@app.post("/agent/run")
+async def run_agent(request: UserRequest):
+    agent = CappuccinoAgent(llm=default_llm, tool_manager=ToolManager())
+    result = await agent.run(request.query)
+    return {"result": result}

--- a/cappuccino_agent.py
+++ b/cappuccino_agent.py
@@ -1,0 +1,38 @@
+import asyncio
+import json
+from typing import Any, Callable, Dict, List, Optional
+
+from tool_manager import ToolManager
+
+
+class CappuccinoAgent:
+    """Minimal asynchronous agent using a ToolManager and pluggable LLM."""
+
+    def __init__(self, llm: Callable[[List[Dict[str, Any]]], Any], tool_manager: Optional[ToolManager] = None):
+        self.llm = llm
+        self.tool_manager = tool_manager or ToolManager()
+        self.messages: List[Dict[str, Any]] = []
+
+    async def run(self, query: str) -> Any:
+        """Run the agent with a user query and return the final response."""
+        self.messages.append({"role": "user", "content": query})
+        response = await self.llm(self.messages)
+        message = response["choices"][0]["message"]
+
+        if message.get("tool_calls"):
+            outputs = []
+            for call in message["tool_calls"]:
+                func_name = call["function"]["name"]
+                args = json.loads(call["function"].get("arguments", "{}"))
+                if hasattr(self.tool_manager, func_name):
+                    func = getattr(self.tool_manager, func_name)
+                    if asyncio.iscoroutinefunction(func):
+                        result = await func(**args)
+                    else:
+                        loop = asyncio.get_running_loop()
+                        result = await loop.run_in_executor(None, func, **args)
+                else:
+                    result = {"error": f"Tool '{func_name}' not found"}
+                outputs.append(result)
+            return outputs
+        return message.get("content")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,19 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api
+
+
+@pytest.mark.asyncio
+async def test_run_endpoint(monkeypatch):
+    async def fake_run(self, query):
+        return "ok"
+
+    monkeypatch.setattr(api.CappuccinoAgent, "run", fake_run)
+    client = TestClient(api.app)
+    resp = client.post("/agent/run", json={"query": "hello"})
+    assert resp.status_code == 200
+    assert resp.json()["result"] == "ok"

--- a/tests/test_cappuccino_agent.py
+++ b/tests/test_cappuccino_agent.py
@@ -1,0 +1,41 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+import pytest_asyncio
+
+from cappuccino_agent import CappuccinoAgent
+from tool_manager import ToolManager
+
+
+@pytest.mark.asyncio
+async def test_agent_runs_tool():
+    async def fake_llm(messages):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "function": {"name": "media_generate_speech", "arguments": "{\"text\": \"hi\", \"output_path\": \"out.wav\"}"}
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+    tm = ToolManager(db_path=":memory:")
+    agent = CappuccinoAgent(llm=fake_llm, tool_manager=tm)
+    result = await agent.run("hi")
+    assert result[0]["error"] == "speech generation not implemented"
+
+
+@pytest.mark.asyncio
+async def test_agent_text_response():
+    async def fake_llm(messages):
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    agent = CappuccinoAgent(llm=fake_llm, tool_manager=ToolManager(db_path=":memory:"))
+    result = await agent.run("hi")
+    assert result == "ok"

--- a/tests/test_tool_manager_all.py
+++ b/tests/test_tool_manager_all.py
@@ -1,0 +1,141 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import asyncio
+import os
+import pytest
+import pytest_asyncio
+
+from tool_manager import ToolManager
+
+
+@pytest_asyncio.fixture()
+async def tm(tmp_path):
+    manager = ToolManager(db_path=os.path.join(tmp_path, "db.sqlite"))
+    yield manager
+    if manager.db_connection:
+        await manager.db_connection.close()
+
+
+@pytest.mark.asyncio
+async def test_agent_management(tm):
+    await tm.agent_update_plan("1", "plan")
+    phase = await tm.agent_advance_phase("1")
+    assert phase["phase"] == 1
+    status = await tm.agent_end_task("1")
+    assert status["status"] == "completed"
+    sched = await tm.agent_schedule_task("1", "daily")
+    assert sched["schedule"] == "daily"
+
+
+@pytest.mark.asyncio
+async def test_message_functions(tm):
+    note = await tm.message_notify_user("u", "hi")
+    assert note["message"] == "hi"
+    ask = await tm.message_ask_user("u", "?")
+    assert ask["status"] == "awaiting"
+
+
+@pytest.mark.asyncio
+async def test_shell_functions(tm):
+    session = "s"
+    await tm.shell_exec("echo hi", session)
+    wait = await tm.shell_wait(session)
+    assert wait["returncode"] == 0
+    # start another session to test kill
+    await tm.shell_exec("sleep 1", "k")
+    kill = await tm.shell_kill("k")
+    assert kill["status"] == "killed"
+    missing = await tm.shell_view("missing")
+    assert "error" in missing
+
+
+@pytest.mark.asyncio
+async def test_file_operations(tm, tmp_path):
+    file_path = tmp_path / "f.txt"
+    await asyncio.to_thread(file_path.write_text, "line1\n")
+    content = await tm.file_read(str(file_path))
+    assert content["content"] == "line1\n"
+    await tm.file_append_text(str(file_path), "line2\n")
+    replaced = await tm.file_replace_text(str(file_path), "line1", "LINE1")
+    assert replaced["status"] == "replaced"
+    not_found = await tm.file_read(str(tmp_path / "none.txt"))
+    assert "error" in not_found
+
+
+@pytest.mark.asyncio
+async def test_media_functions(tm, tmp_path):
+    img_path = tmp_path / "img.png"
+    result = await tm.media_generate_image("hi", str(img_path))
+    assert os.path.exists(result["path"])
+    speech = await tm.media_generate_speech("hi", "out.wav")
+    assert "error" in speech
+
+
+@pytest.mark.asyncio
+async def test_info_search(tm, monkeypatch):
+    class Resp:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def text(self):
+            return "<a class='result__a' href='http://x'>title</a>"
+
+    class Session:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        def get(self, url, params=None):
+            return Resp()
+
+    monkeypatch.setattr("aiohttp.ClientSession", lambda: Session())
+    web = await tm.info_search_web("test")
+    assert web["results"][0]["title"] == "title"
+
+    api_resp = await tm.info_search_api("http://x", None)
+    assert "response" in api_resp
+
+    image = await tm.info_search_image("q")
+    assert "error" in image
+
+
+@pytest.mark.asyncio
+async def test_browser_and_service_placeholders(tm):
+    funcs = [
+        tm.browser_navigate,
+        tm.browser_view,
+        tm.browser_click,
+        tm.browser_input,
+        tm.browser_move_mouse,
+        tm.browser_press_key,
+        tm.browser_select_option,
+        tm.browser_save_image,
+        tm.browser_scroll_up,
+        tm.browser_scroll_down,
+        tm.browser_console_exec,
+        tm.browser_console_view,
+        tm.service_expose_port,
+        tm.service_deploy_frontend,
+        tm.service_deploy_backend,
+    ]
+    for func in funcs:
+        arg_count = func.__code__.co_argcount - 1
+        if arg_count == 0:
+            result = await func()
+        elif arg_count == 1:
+            arg = 1 if 'service_expose_port' in func.__name__ else "x"
+            result = await func(arg)
+        else:
+            result = await func("x", "y")
+        assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_slide_functions(tm, tmp_path):
+    proj = tmp_path / "proj"
+    init = await tm.slide_initialize(str(proj))
+    assert os.path.exists(init["project"])
+    present = await tm.slide_present(str(proj))
+    assert present["status"] == "presenting"


### PR DESCRIPTION
## Summary
- implement minimal `CappuccinoAgent`
- expose a small FastAPI API
- create integration tests using mocked LLM responses
- expand ToolManager testing to cover all functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc1aa47dc832c8ae9067985bbaa6a