### PR TITLE
Add CI workflow and test requirements

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,26 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      SEARCH_API_KEY: ${{ secrets.SEARCH_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest -q

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# cappuccino
+# Cappuccino
+
+This repository contains asynchronous tools for the Cappuccino agent and a small test suite.
+
+## Running Tests
+
+Install dependencies and run the tests using `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest -q
+```
+
+## Continuous Integration
+
+A GitHub Actions workflow installs the dependencies defined in `requirements.txt` and runs the test suite on every push and pull request. API keys such as `OPENAI_API_KEY` and `SEARCH_API_KEY` are provided to the workflow via repository secrets so no sensitive values are committed to the repository.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+aiosqlite
+aiohttp
+beautifulsoup4
+Pillow
+pytest
+pytest-asyncio


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run pytest
- define dependencies in `requirements.txt`
- document how to run tests and mention using GitHub secrets for API keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc1ab40b4832ca5cd83380eafdfc2