### PR TITLE
Add configuration module and agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # cappuccino
+
+This project provides a set of tools for building the **Cappuccino** AI agent.
+
+## Configuration
+
+The agent reads credentials such as the OpenAI API key from environment variables.
+Set `OPENAI_API_KEY` before running the agent:
+
+```bash
+export OPENAI_API_KEY=your-key
+```

--- a/cappuccino_agent.py
+++ b/cappuccino_agent.py
@@ -1,0 +1,40 @@
+import json
+import logging
+from typing import List, Dict, Optional
+
+from openai import OpenAI
+
+from tool_manager import ToolManager
+from config import settings
+
+
+class CappuccinoAgent:
+    """Simple agent that communicates with OpenAI's API using ToolManager."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.client = OpenAI(api_key=api_key or settings.openai_api_key)
+        self.tool_manager = ToolManager()
+        self.messages: List[Dict[str, str]] = []
+        self._initialize_system_prompt()
+
+    def _initialize_system_prompt(self) -> None:
+        prompt = (
+            "You are Cappuccino, a helpful AI assistant. "
+            "Respond in Japanese."
+        )
+        self.messages.append({"role": "system", "content": prompt})
+
+    def _add_message(self, role: str, content: str) -> None:
+        self.messages.append({"role": role, "content": content})
+        logging.info("Added message: %s", content)
+
+    def run(self, user_query: str) -> str:
+        """Send the query to OpenAI and return the response text."""
+        self._add_message("user", user_query)
+        response = self.client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=self.messages,
+        )
+        message = response.choices[0].message
+        self._add_message(message.role, message.content or "")
+        return message.content or ""

--- a/config.py
+++ b/config.py
@@ -1,0 +1,11 @@
+import os
+from dataclasses import dataclass
+
+@dataclass
+class Settings:
+    """Application configuration loaded from environment variables."""
+    openai_api_key: str = os.getenv("OPENAI_API_KEY", "")
+    anthropic_api_key: str | None = os.getenv("ANTHROPIC_API_KEY")
+    azure_openai_key: str | None = os.getenv("AZURE_OPENAI_API_KEY")
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- add `config.py` to load API credentials from environment variables
- implement a basic `CappuccinoAgent` that reads the OpenAI API key from `config`
- document the `OPENAI_API_KEY` environment variable in README

## Testing
- `pip install aiosqlite`
- `pip install pillow`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc28e2a30832cb77ee5b007059581