### PR TITLE
Implement caching for agent

### DIFF
--- a/cappuccino_agent.py
+++ b/cappuccino_agent.py
@@ -1,0 +1,30 @@
+import json
+from typing import Any, Dict, Optional
+
+from tool_manager import ToolManager
+
+class CappuccinoAgent:
+    """Simplified agent demonstrating cache integration."""
+
+    def __init__(self, tool_manager: Optional[ToolManager] = None):
+        self.tool_manager = tool_manager or ToolManager()
+        self.messages: list[Dict[str, Any]] = []
+
+    async def get_cached_result(self, key: str) -> Optional[str]:
+        return await self.tool_manager.get_cached_result(key)
+
+    async def set_cached_result(self, key: str, value: str) -> None:
+        await self.tool_manager.set_cached_result(key, value)
+
+    async def call_llm(self, prompt: str) -> str:
+        """Example LLM call with caching. Actual LLM integration omitted."""
+        cache_key = f"llm:{prompt}"
+        cached = await self.get_cached_result(cache_key)
+        if cached:
+            return cached
+        # Placeholder LLM response
+        response = prompt[::-1]
+        await self.set_cached_result(cache_key, response)
+        self.messages.append({"role": "user", "content": prompt})
+        self.messages.append({"role": "assistant", "content": response})
+        return response

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,23 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import asyncio
+import os
+import pytest
+
+from tool_manager import ToolManager
+from cappuccino_agent import CappuccinoAgent
+
+@pytest.mark.asyncio
+async def test_cache_methods(tmp_path):
+    tm = ToolManager(db_path=os.path.join(tmp_path, "db.sqlite"))
+    await tm.set_cached_result("foo", "bar")
+    value = await tm.get_cached_result("foo")
+    assert value == "bar"
+
+@pytest.mark.asyncio
+async def test_agent_cache(tmp_path):
+    tm = ToolManager(db_path=os.path.join(tmp_path, "db.sqlite"))
+    agent = CappuccinoAgent(tool_manager=tm)
+    response = await agent.call_llm("hello")
+    assert response == "olleh"
+    cached = await agent.get_cached_result("llm:hello")
+    assert cached == "olleh"

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -40,6 +40,32 @@ class ToolManager:
                     content TEXT
             )"""
         )
+        await conn.execute(
+            """CREATE TABLE IF NOT EXISTS cache (
+                    key TEXT PRIMARY KEY,
+                    value TEXT,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )"""
+        )
+        await conn.commit()
+
+    # ------------------------------------------------------------------
+    # Cache management
+    # ------------------------------------------------------------------
+    async def get_cached_result(self, key: str) -> Optional[str]:
+        """Retrieve a cached value by key."""
+        conn = await self._get_db_connection()
+        cur = await conn.execute("SELECT value FROM cache WHERE key=?", (key,))
+        row = await cur.fetchone()
+        return row[0] if row else None
+
+    async def set_cached_result(self, key: str, value: str) -> None:
+        """Store a value in the cache."""
+        conn = await self._get_db_connection()
+        await conn.execute(
+            "REPLACE INTO cache(key, value) VALUES(?, ?)",
+            (key, value),
+        )
         await conn.commit()
 
     # ------------------------------------------------------------------
@@ -222,6 +248,11 @@ class ToolManager:
     # ------------------------------------------------------------------
     async def info_search_web(self, query: str) -> Dict[str, Any]:
         """Search the web using DuckDuckGo and return titles and links."""
+        cache_key = f"info_search_web:{query}"
+        cached = await self.get_cached_result(cache_key)
+        if cached:
+            return json.loads(cached)
+
         import aiohttp
         from bs4 import BeautifulSoup
 
@@ -233,7 +264,9 @@ class ToolManager:
         results = []
         for a in soup.select("a.result__a"):
             results.append({"title": a.text, "href": a.get("href")})
-        return {"results": results}
+        output = {"results": results}
+        await self.set_cached_result(cache_key, json.dumps(output))
+        return output
 
     async def info_search_image(self, query: str) -> Dict[str, Any]:
         """Placeholder for image search."""


### PR DESCRIPTION
## Summary
- add cache table to SQLite initialization
- implement `get_cached_result` and `set_cached_result`
- cache results in `info_search_web`
- add simple `CappuccinoAgent` showing cache usage
- test cache behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc28e5234832cb76e8edf260ebcea