### PR TITLE
Add workspace root validation to ToolManager

### DIFF
--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -6,7 +6,7 @@ from tool_manager import ToolManager
 
 @pytest.mark.asyncio
 async def test_file_read_and_append(tmp_path):
-    tm = ToolManager(db_path=os.path.join(tmp_path, "db.sqlite"))
+    tm = ToolManager(db_path=os.path.join(tmp_path, "db.sqlite"), root_dir=str(tmp_path))
     file_path = tmp_path / "sample.txt"
     await asyncio.to_thread(file_path.write_text, "hello\n")
     result = await tm.file_read(str(file_path))
@@ -16,11 +16,22 @@ async def test_file_read_and_append(tmp_path):
     assert result["content"] == "hello\nworld\n"
 
 @pytest.mark.asyncio
-async def test_shell_exec_and_wait():
-    tm = ToolManager(db_path=":memory:")
+async def test_shell_exec_and_wait(tmp_path):
+    tm = ToolManager(db_path=":memory:", root_dir=str(tmp_path))
     session_id = "test"
     await tm.shell_exec("echo hello", session_id)
     result = await tm.shell_wait(session_id)
     assert result["returncode"] == 0
     assert "hello" in result["stdout"]
+
+
+@pytest.mark.asyncio
+async def test_disallowed_path(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    tm = ToolManager(db_path=os.path.join(root, "db.sqlite"), root_dir=str(root))
+    outside = tmp_path / "outside.txt"
+    await asyncio.to_thread(outside.write_text, "secret")
+    result = await tm.file_read(str(outside))
+    assert "error" in result
 

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -10,10 +10,21 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 class ToolManager:
     """Collection of asynchronous tools for the Cappuccino agent."""
 
-    def __init__(self, db_path: str = "agent_state.db"):
+    def __init__(self, db_path: str = "agent_state.db", root_dir: Optional[str] = None):
         self.db_path = db_path
+        self.root_dir = os.path.abspath(root_dir or os.getcwd())
         self.db_connection: Optional[aiosqlite.Connection] = None
         self.shell_sessions: Dict[str, asyncio.subprocess.Process] = {}
+
+    # ------------------------------------------------------------------
+    # Path utilities
+    # ------------------------------------------------------------------
+    def _validate_path(self, path: str) -> str:
+        """Return an absolute path restricted to the workspace root."""
+        abs_path = os.path.abspath(path if os.path.isabs(path) else os.path.join(self.root_dir, path))
+        if os.path.commonpath([abs_path, self.root_dir]) != self.root_dir:
+            raise ValueError("Access outside workspace root is not allowed")
+        return abs_path
 
     async def _get_db_connection(self) -> aiosqlite.Connection:
         if self.db_connection is None:
@@ -115,6 +126,10 @@ class ToolManager:
     # ------------------------------------------------------------------
     async def shell_exec(self, command: str, session_id: str, working_dir: str = ".") -> Dict[str, Any]:
         """Execute a shell command asynchronously and store the session."""
+        try:
+            working_dir = self._validate_path(working_dir)
+        except ValueError as e:
+            return {"error": str(e)}
         process = await asyncio.create_subprocess_shell(
             command,
             cwd=working_dir,
@@ -169,6 +184,10 @@ class ToolManager:
     # ------------------------------------------------------------------
     async def file_read(self, abs_path: str, start_line: Optional[int] = None, end_line: Optional[int] = None) -> Dict[str, Any]:
         """Read a text file and optionally limit lines."""
+        try:
+            abs_path = self._validate_path(abs_path)
+        except ValueError as e:
+            return {"error": str(e)}
         if not os.path.exists(abs_path):
             return {"error": "File not found"}
         content = await asyncio.to_thread(lambda: open(abs_path, "r").read())
@@ -179,6 +198,10 @@ class ToolManager:
 
     async def file_append_text(self, abs_path: str, text: str) -> Dict[str, Any]:
         """Append text to a file."""
+        try:
+            abs_path = self._validate_path(abs_path)
+        except ValueError as e:
+            return {"error": str(e)}
         await asyncio.to_thread(self._append_text, abs_path, text)
         return {"status": "appended"}
 
@@ -188,6 +211,10 @@ class ToolManager:
 
     async def file_replace_text(self, abs_path: str, old: str, new: str) -> Dict[str, Any]:
         """Replace text in a file."""
+        try:
+            abs_path = self._validate_path(abs_path)
+        except ValueError as e:
+            return {"error": str(e)}
         if not os.path.exists(abs_path):
             return {"error": "File not found"}
         await asyncio.to_thread(self._replace_text, abs_path, old, new)
@@ -205,11 +232,17 @@ class ToolManager:
     # ------------------------------------------------------------------
     async def media_generate_image(self, text: str, output_path: str) -> Dict[str, Any]:
         """Generate a simple image with text."""
+        try:
+            output_path = self._validate_path(output_path)
+        except ValueError as e:
+            return {"error": str(e)}
+
         def _generate() -> None:
             img = Image.new("RGB", (400, 200), color="white")
             draw = ImageDraw.Draw(img)
             draw.text((10, 90), text, fill="black")
             img.save(output_path)
+
         await asyncio.to_thread(_generate)
         return {"path": output_path}
 
@@ -293,18 +326,34 @@ class ToolManager:
         return {"error": "service management not implemented"}
 
     async def service_deploy_frontend(self, source_dir: str) -> Dict[str, Any]:
+        try:
+            _ = self._validate_path(source_dir)
+        except ValueError as e:
+            return {"error": str(e)}
         return {"error": "service management not implemented"}
 
     async def service_deploy_backend(self, source_dir: str) -> Dict[str, Any]:
+        try:
+            _ = self._validate_path(source_dir)
+        except ValueError as e:
+            return {"error": str(e)}
         return {"error": "service management not implemented"}
 
     # ------------------------------------------------------------------
     # Slide presentation (placeholders)
     # ------------------------------------------------------------------
     async def slide_initialize(self, project_name: str) -> Dict[str, Any]:
-        os.makedirs(project_name, exist_ok=True)
-        return {"project": project_name}
+        try:
+            project_path = self._validate_path(project_name)
+        except ValueError as e:
+            return {"error": str(e)}
+        os.makedirs(project_path, exist_ok=True)
+        return {"project": project_path}
 
     async def slide_present(self, project_name: str) -> Dict[str, Any]:
-        return {"project": project_name, "status": "presenting"}
+        try:
+            project_path = self._validate_path(project_name)
+        except ValueError as e:
+            return {"error": str(e)}
+        return {"project": project_path, "status": "presenting"}
 


### PR DESCRIPTION
## Summary
- protect file operations by defining a workspace root directory
- block paths outside the workspace using `os.path.commonpath`
- update file-based methods and shell execution to use the validator
- extend tests to verify allowed and disallowed paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc28ffc60832c8e4efa5b9b5d2b9b