### PR TITLE
Improve error handling with structured logs

### DIFF
--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -1,8 +1,9 @@
 import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import asyncio
 import os
+import logging
 import pytest
-from tool_manager import ToolManager
+from tool_manager import ToolManager, ToolExecutionError
 
 @pytest.mark.asyncio
 async def test_file_read_and_append(tmp_path):
@@ -23,4 +24,20 @@ async def test_shell_exec_and_wait():
     result = await tm.shell_wait(session_id)
     assert result["returncode"] == 0
     assert "hello" in result["stdout"]
+
+
+@pytest.mark.asyncio
+async def test_file_read_not_found(tmp_path):
+    tm = ToolManager(db_path=os.path.join(tmp_path, "db.sqlite"))
+    with pytest.raises(FileNotFoundError):
+        await tm.file_read(str(tmp_path / "missing.txt"))
+
+
+@pytest.mark.asyncio
+async def test_shell_wait_no_session(caplog):
+    tm = ToolManager(db_path=":memory:")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ToolExecutionError):
+            await tm.shell_wait("bad")
+    assert any("shell_wait" in r.getMessage() for r in caplog.records)
 

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -2,11 +2,40 @@ import asyncio
 import os
 import json
 import logging
+import inspect
+from functools import wraps
 from typing import Any, Dict, Optional
 
 import aiosqlite
 from PIL import Image, ImageDraw, ImageFont
+
+
+class ToolExecutionError(Exception):
+    """Raised when a tool encounters an error during execution."""
+
+
+logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+
+def log_tool(func):
+    """Decorator to log tool execution with parameters and errors."""
+
+    @wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        bound = inspect.signature(func).bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        params = {k: v for k, v in bound.arguments.items() if k != "self"}
+        logger.info("tool=%s params=%s", func.__name__, params)
+        try:
+            return await func(self, *args, **kwargs)
+        except Exception as exc:
+            logger.exception("tool=%s params=%s", func.__name__, params)
+            raise exc
+
+    return wrapper
+
+
 class ToolManager:
     """Collection of asynchronous tools for the Cappuccino agent."""
 
@@ -45,6 +74,7 @@ class ToolManager:
     # ------------------------------------------------------------------
     # Agent management
     # ------------------------------------------------------------------
+    @log_tool
     async def agent_update_plan(self, task_id: str, plan: str) -> Dict[str, Any]:
         """Create or update a task plan."""
         conn = await self._get_db_connection()
@@ -55,6 +85,7 @@ class ToolManager:
         await conn.commit()
         return {"task_id": task_id, "plan": plan}
 
+    @log_tool
     async def agent_advance_phase(self, task_id: str) -> Dict[str, Any]:
         """Advance task to the next phase."""
         conn = await self._get_db_connection()
@@ -67,6 +98,7 @@ class ToolManager:
         row = await cur.fetchone()
         return {"task_id": task_id, "phase": row[0] if row else None}
 
+    @log_tool
     async def agent_end_task(self, task_id: str) -> Dict[str, Any]:
         """Mark task as completed."""
         conn = await self._get_db_connection()
@@ -77,6 +109,7 @@ class ToolManager:
         await conn.commit()
         return {"task_id": task_id, "status": "completed"}
 
+    @log_tool
     async def agent_schedule_task(self, task_id: str, schedule: str) -> Dict[str, Any]:
         """Set schedule information for a task."""
         conn = await self._get_db_connection()
@@ -90,6 +123,7 @@ class ToolManager:
     # ------------------------------------------------------------------
     # Messaging
     # ------------------------------------------------------------------
+    @log_tool
     async def message_notify_user(self, user_id: str, message: str) -> Dict[str, Any]:
         """Store a notification for the user."""
         conn = await self._get_db_connection()
@@ -100,6 +134,7 @@ class ToolManager:
         await conn.commit()
         return {"user_id": user_id, "message": message}
 
+    @log_tool
     async def message_ask_user(self, user_id: str, question: str) -> Dict[str, Any]:
         """Store a question for the user and return placeholder for response."""
         conn = await self._get_db_connection()
@@ -113,6 +148,7 @@ class ToolManager:
     # ------------------------------------------------------------------
     # Shell management
     # ------------------------------------------------------------------
+    @log_tool
     async def shell_exec(self, command: str, session_id: str, working_dir: str = ".") -> Dict[str, Any]:
         """Execute a shell command asynchronously and store the session."""
         process = await asyncio.create_subprocess_shell(
@@ -125,20 +161,22 @@ class ToolManager:
         self.shell_sessions[session_id] = process
         return {"session_id": session_id, "status": "running"}
 
+    @log_tool
     async def shell_view(self, session_id: str) -> Dict[str, Any]:
         """Return current stdout and stderr for the session."""
         process = self.shell_sessions.get(session_id)
         if not process:
-            return {"error": "session not found"}
+            raise ToolExecutionError("session not found")
         stdout = await process.stdout.read() if not process.stdout.at_eof() else b""
         stderr = await process.stderr.read() if not process.stderr.at_eof() else b""
         return {"stdout": stdout.decode(), "stderr": stderr.decode()}
 
+    @log_tool
     async def shell_wait(self, session_id: str) -> Dict[str, Any]:
         """Wait for the process to complete and return outputs."""
         process = self.shell_sessions.get(session_id)
         if not process:
-            return {"error": "session not found"}
+            raise ToolExecutionError("session not found")
         stdout, stderr = await process.communicate()
         return {
             "returncode": process.returncode,
@@ -146,20 +184,22 @@ class ToolManager:
             "stderr": stderr.decode(),
         }
 
+    @log_tool
     async def shell_input(self, session_id: str, text: str) -> Dict[str, Any]:
         """Send input to the running shell session."""
         process = self.shell_sessions.get(session_id)
         if not process or process.stdin is None:
-            return {"error": "session not found"}
+            raise ToolExecutionError("session not found")
         process.stdin.write(text.encode())
         await process.stdin.drain()
         return {"status": "sent"}
 
+    @log_tool
     async def shell_kill(self, session_id: str) -> Dict[str, Any]:
         """Terminate the shell session."""
         process = self.shell_sessions.get(session_id)
         if not process:
-            return {"error": "session not found"}
+            raise ToolExecutionError("session not found")
         process.kill()
         await process.wait()
         return {"status": "killed"}
@@ -167,16 +207,18 @@ class ToolManager:
     # ------------------------------------------------------------------
     # File operations
     # ------------------------------------------------------------------
+    @log_tool
     async def file_read(self, abs_path: str, start_line: Optional[int] = None, end_line: Optional[int] = None) -> Dict[str, Any]:
         """Read a text file and optionally limit lines."""
         if not os.path.exists(abs_path):
-            return {"error": "File not found"}
+            raise FileNotFoundError(abs_path)
         content = await asyncio.to_thread(lambda: open(abs_path, "r").read())
         lines = content.splitlines(True)
         if start_line is not None or end_line is not None:
             lines = lines[start_line:end_line]
         return {"content": "".join(lines)}
 
+    @log_tool
     async def file_append_text(self, abs_path: str, text: str) -> Dict[str, Any]:
         """Append text to a file."""
         await asyncio.to_thread(self._append_text, abs_path, text)
@@ -186,10 +228,11 @@ class ToolManager:
         with open(abs_path, "a") as f:
             f.write(text)
 
+    @log_tool
     async def file_replace_text(self, abs_path: str, old: str, new: str) -> Dict[str, Any]:
         """Replace text in a file."""
         if not os.path.exists(abs_path):
-            return {"error": "File not found"}
+            raise FileNotFoundError(abs_path)
         await asyncio.to_thread(self._replace_text, abs_path, old, new)
         return {"status": "replaced"}
 
@@ -203,6 +246,7 @@ class ToolManager:
     # ------------------------------------------------------------------
     # Media generation
     # ------------------------------------------------------------------
+    @log_tool
     async def media_generate_image(self, text: str, output_path: str) -> Dict[str, Any]:
         """Generate a simple image with text."""
         def _generate() -> None:
@@ -213,13 +257,15 @@ class ToolManager:
         await asyncio.to_thread(_generate)
         return {"path": output_path}
 
+    @log_tool
     async def media_generate_speech(self, text: str, output_path: str) -> Dict[str, Any]:
         """Placeholder for speech generation."""
-        return {"error": "speech generation not implemented"}
+        raise NotImplementedError("speech generation not implemented")
 
     # ------------------------------------------------------------------
     # Information search
     # ------------------------------------------------------------------
+    @log_tool
     async def info_search_web(self, query: str) -> Dict[str, Any]:
         """Search the web using DuckDuckGo and return titles and links."""
         import aiohttp
@@ -235,10 +281,12 @@ class ToolManager:
             results.append({"title": a.text, "href": a.get("href")})
         return {"results": results}
 
+    @log_tool
     async def info_search_image(self, query: str) -> Dict[str, Any]:
         """Placeholder for image search."""
-        return {"error": "image search not implemented"}
+        raise NotImplementedError("image search not implemented")
 
+    @log_tool
     async def info_search_api(self, url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Perform a generic API GET request."""
         import aiohttp
@@ -250,61 +298,78 @@ class ToolManager:
     # ------------------------------------------------------------------
     # Browser automation (placeholders)
     # ------------------------------------------------------------------
+    @log_tool
     async def browser_navigate(self, url: str) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        raise NotImplementedError("browser automation not implemented")
 
+    @log_tool
     async def browser_view(self) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        raise NotImplementedError("browser automation not implemented")
 
+    @log_tool
     async def browser_click(self, selector: str) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        raise NotImplementedError("browser automation not implemented")
 
+    @log_tool
     async def browser_input(self, selector: str, text: str) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        raise NotImplementedError("browser automation not implemented")
 
+    @log_tool
     async def browser_move_mouse(self, x: int, y: int) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        raise NotImplementedError("browser automation not implemented")
 
+    @log_tool
     async def browser_press_key(self, key: str) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        raise NotImplementedError("browser automation not implemented")
 
+    @log_tool
     async def browser_select_option(self, selector: str, option: str) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        raise NotImplementedError("browser automation not implemented")
 
+    @log_tool
     async def browser_save_image(self, selector: str, output_path: str) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        raise NotImplementedError("browser automation not implemented")
 
+    @log_tool
     async def browser_scroll_up(self, amount: int) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        raise NotImplementedError("browser automation not implemented")
 
+    @log_tool
     async def browser_scroll_down(self, amount: int) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        raise NotImplementedError("browser automation not implemented")
 
+    @log_tool
     async def browser_console_exec(self, script: str) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        raise NotImplementedError("browser automation not implemented")
 
+    @log_tool
     async def browser_console_view(self) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        raise NotImplementedError("browser automation not implemented")
 
     # ------------------------------------------------------------------
     # Service deployment (placeholders)
     # ------------------------------------------------------------------
+    @log_tool
     async def service_expose_port(self, port: int) -> Dict[str, Any]:
-        return {"error": "service management not implemented"}
+        raise NotImplementedError("service management not implemented")
 
+    @log_tool
     async def service_deploy_frontend(self, source_dir: str) -> Dict[str, Any]:
-        return {"error": "service management not implemented"}
+        raise NotImplementedError("service management not implemented")
 
+    @log_tool
     async def service_deploy_backend(self, source_dir: str) -> Dict[str, Any]:
-        return {"error": "service management not implemented"}
+        raise NotImplementedError("service management not implemented")
 
     # ------------------------------------------------------------------
     # Slide presentation (placeholders)
     # ------------------------------------------------------------------
+    @log_tool
     async def slide_initialize(self, project_name: str) -> Dict[str, Any]:
         os.makedirs(project_name, exist_ok=True)
         return {"project": project_name}
 
+    @log_tool
     async def slide_present(self, project_name: str) -> Dict[str, Any]:
         return {"project": project_name, "status": "presenting"}
 


### PR DESCRIPTION
## Summary
- introduce `ToolExecutionError` and a `log_tool` decorator
- raise exceptions instead of returning error strings
- log tool usage and errors with parameters
- test that exceptions are raised and errors logged

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc2913af8832c9ab5e5a3be637de1