### PR TITLE
Fix run_agent return

### DIFF
--- a/api.py
+++ b/api.py
@@ -49,7 +49,8 @@ class ToolCallResult(BaseModel):
 
 @app.post("/agent/run")
 async def run_agent(request: RunRequest) -> Dict[str, Any]:
-    return await agent.run(request.query)
+    result = await agent.run(request.query)
+    return {"result": result}
 
 
 @app.get("/agent/status")


### PR DESCRIPTION
## Summary
- wrap `run_agent` result for clients

## Testing
- `pytest tests/test_api.py -q`
- `pytest -q` *(fails: wraps NameError from tool_manager, ImportError for StateManager)*

------
https://chatgpt.com/codex/tasks/task_e_686fd1191428832c818283540efabf55