### PR TITLE
fix: add missing imports in tool manager

### DIFF
--- a/tool_manager.py
+++ b/tool_manager.py
@@ -6,6 +6,11 @@ import wave
 import sys
 from typing import Any, Dict, Optional, List
 
+import os
+import inspect
+from functools import wraps
+import json
+
 
 import aiosqlite
 from PIL import Image, ImageDraw, ImageFont


### PR DESCRIPTION
## Summary
- add missing imports for `os`, `inspect`, `wraps`, and `json` at the top of `tool_manager.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ImportError: cannot import name 'StateManager')*

------
https://chatgpt.com/codex/tasks/task_e_686fd1170754832c9e55d8d581c73319