### PR TITLE
Handle placeholder tools gracefully

### DIFF
--- a/tool_manager.py
+++ b/tool_manager.py
@@ -5,6 +5,9 @@ import struct
 import wave
 import sys
 from typing import Any, Dict, Optional, List
+import os
+import inspect
+from functools import wraps
 
 
 import aiosqlite
@@ -25,12 +28,15 @@ def log_tool(func):
 
     @wraps(func)
     async def wrapper(self, *args, **kwargs):
-        bound = inspect.signature(func).bind(self, *args, **kwargs)
+        bound = inspect.signature(func).bind_partial(self, *args, **kwargs)
         bound.apply_defaults()
         params = {k: v for k, v in bound.arguments.items() if k != "self"}
         logger.info("tool=%s params=%s", func.__name__, params)
         try:
             return await func(self, *args, **kwargs)
+        except TypeError as exc:
+            logger.exception("tool=%s params=%s", func.__name__, params)
+            return {"error": str(exc)}
         except Exception as exc:
             logger.exception("tool=%s params=%s", func.__name__, params)
             raise exc
@@ -458,43 +464,43 @@ class ToolManager:
 
     @log_tool
     async def browser_click(self, selector: str) -> Dict[str, Any]:
-        raise NotImplementedError("browser automation not implemented")
+        return {"error": "browser automation not implemented"}
 
     @log_tool
     async def browser_input(self, selector: str, text: str) -> Dict[str, Any]:
-        raise NotImplementedError("browser automation not implemented")
+        return {"error": "browser automation not implemented"}
 
     @log_tool
     async def browser_move_mouse(self, x: int, y: int) -> Dict[str, Any]:
-        raise NotImplementedError("browser automation not implemented")
+        return {"error": "browser automation not implemented"}
 
     @log_tool
     async def browser_press_key(self, key: str) -> Dict[str, Any]:
-        raise NotImplementedError("browser automation not implemented")
+        return {"error": "browser automation not implemented"}
 
     @log_tool
     async def browser_select_option(self, selector: str, option: str) -> Dict[str, Any]:
-        raise NotImplementedError("browser automation not implemented")
+        return {"error": "browser automation not implemented"}
 
     @log_tool
     async def browser_save_image(self, selector: str, output_path: str) -> Dict[str, Any]:
-        raise NotImplementedError("browser automation not implemented")
+        return {"error": "browser automation not implemented"}
 
     @log_tool
     async def browser_scroll_up(self, amount: int) -> Dict[str, Any]:
-        raise NotImplementedError("browser automation not implemented")
+        return {"error": "browser automation not implemented"}
 
     @log_tool
     async def browser_scroll_down(self, amount: int) -> Dict[str, Any]:
-        raise NotImplementedError("browser automation not implemented")
+        return {"error": "browser automation not implemented"}
 
     @log_tool
     async def browser_console_exec(self, script: str) -> Dict[str, Any]:
-        raise NotImplementedError("browser automation not implemented")
+        return {"error": "browser automation not implemented"}
 
     @log_tool
     async def browser_console_view(self) -> Dict[str, Any]:
-        raise NotImplementedError("browser automation not implemented")
+        return {"error": "browser automation not implemented"}
 
     # ------------------------------------------------------------------
     # Service deployment (placeholders)
@@ -514,20 +520,27 @@ class ToolManager:
             thread.start()
             return httpd
 
-        server = await asyncio.to_thread(_start_server)
-        actual_port = server.server_address[1]
-        self.service_processes[actual_port] = server
-        return {"port": actual_port, "status": "running"}
+        try:
+            port = int(port)
+        except Exception as e:
+            return {"error": str(e)}
+
+        try:
+            server = await asyncio.to_thread(_start_server)
+            actual_port = server.server_address[1]
+            self.service_processes[actual_port] = server
+            return {"port": actual_port, "status": "running"}
+        except Exception as e:
+            return {"error": str(e)}
 
 
     @log_tool
     async def service_deploy_frontend(self, source_dir: str) -> Dict[str, Any]:
-
-        raise NotImplementedError("service management not implemented")
+        return {"error": "service management not implemented"}
 
     @log_tool
     async def service_deploy_backend(self, source_dir: str) -> Dict[str, Any]:
-        raise NotImplementedError("service management not implemented")
+        return {"error": "service management not implemented"}
 
     # ------------------------------------------------------------------
     # Slide presentation (placeholders)


### PR DESCRIPTION
## Summary
- import missing utilities for `tool_manager`
- return error dictionaries for browser and service placeholder functions
- handle missing arguments in `log_tool`
- validate and catch errors in `service_expose_port`

## Testing
- `pytest tests/test_tool_manager_all.py::test_browser_and_service_placeholders -q`

------
https://chatgpt.com/codex/tasks/task_e_686fd11a4b2c832cbbbff7e920d05f90