### PR TITLE
Add chat CLI utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ Key principles from `AGENTS.md`:
 ## Next steps
 Additional development plans in Japanese can be found in [docs/NEXT_STEPS_JA.md](docs/NEXT_STEPS_JA.md).
 
+
+## Chat CLI
+Run a simple interactive chat loop from the terminal:
+```bash
+python chat_cli.py
+```
+Exit the session with `exit` or `quit`.

--- a/chat_cli.py
+++ b/chat_cli.py
@@ -1,0 +1,34 @@
+import asyncio
+from typing import Optional
+
+from cappuccino_agent import CappuccinoAgent
+from tool_manager import ToolManager
+from config import settings
+
+
+async def chat_once(agent: CappuccinoAgent, message: str) -> str:
+    """Send a single message to the agent and return its response."""
+    try:
+        result = await agent.run(message)
+    except Exception as exc:  # pragma: no cover - defensive
+        return f"error: {exc}"
+    return result if isinstance(result, str) else str(result)
+
+
+async def chat_loop(api_key: Optional[str] = None) -> None:
+    """Interactive CLI chat loop with the Cappuccino agent."""
+    agent = CappuccinoAgent(api_key=api_key or settings.openai_api_key,
+                           tool_manager=ToolManager(db_path=":memory:"))
+    try:
+        while True:
+            user_input = input("You: ")
+            if user_input.lower() in {"exit", "quit"}:
+                break
+            response = await chat_once(agent, user_input)
+            print(f"Cappuccino: {response}")
+    finally:
+        await agent.close()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    asyncio.run(chat_loop())

--- a/tests/test_chat_cli.py
+++ b/tests/test_chat_cli.py
@@ -1,0 +1,18 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from chat_cli import chat_once
+from cappuccino_agent import CappuccinoAgent
+
+
+@pytest.mark.asyncio
+async def test_chat_once(monkeypatch):
+    async def fake_run(self, msg):
+        return "pong"
+
+    monkeypatch.setattr(CappuccinoAgent, "run", fake_run)
+    agent = CappuccinoAgent(tool_manager=None, llm=None)
+    response = await chat_once(agent, "ping")
+    assert response == "pong"


### PR DESCRIPTION
## Summary
- implement a small interactive chat loop in `chat_cli.py`
- test `chat_once` helper
- document usage in README

## Testing
- `ruff check chat_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68719f6e08f4832c95d0b9b2627250af