### PR TITLE
Resolve Ruff lint errors

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
-import sys, pathlib
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,7 @@
-import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-import asyncio
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 import os
 import pytest
 

--- a/tests/test_cappuccino_agent.py
+++ b/tests/test_cappuccino_agent.py
@@ -1,9 +1,10 @@
 
-import sys, pathlib
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pytest
-import pytest_asyncio
 
 from cappuccino_agent import CappuccinoAgent
 from tool_manager import ToolManager

--- a/tests/test_chat_cli.py
+++ b/tests/test_chat_cli.py
@@ -1,5 +1,7 @@
-import sys, pathlib
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pytest
 

--- a/tests/test_planner_state.py
+++ b/tests/test_planner_state.py
@@ -1,7 +1,7 @@
-import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-import asyncio
-import os
-import pathlib
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pytest
 

--- a/tests/test_tool_autogen.py
+++ b/tests/test_tool_autogen.py
@@ -1,5 +1,7 @@
-import sys, pathlib
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 import pytest
 import openai
 from tool_manager import ToolManager

--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -1,13 +1,14 @@
-import pathlib
 import sys
+from pathlib import Path
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 import asyncio
 import os
 
 import logging
 import pytest
-from tool_manager import ToolManager, ToolExecutionError
+import cv2
+from tool_manager import ToolManager
 
 
 
@@ -101,8 +102,6 @@ async def test_media_analyze_video(monkeypatch):
             return True
 
         def get(self, prop):
-            import cv2
-
             if prop == cv2.CAP_PROP_FRAME_COUNT:
                 return 10
             if prop == cv2.CAP_PROP_FPS:
@@ -115,8 +114,6 @@ async def test_media_analyze_video(monkeypatch):
 
         def release(self):
             pass
-
-    import cv2
 
     monkeypatch.setattr("cv2.VideoCapture", lambda path: DummyCap(path))
     result = await tm.media_analyze_video("dummy.mp4")

--- a/tests/test_tool_manager_all.py
+++ b/tests/test_tool_manager_all.py
@@ -1,5 +1,7 @@
-import sys, pathlib
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import asyncio
 import os

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -4,10 +4,10 @@ import os
 import json
 import inspect
 from functools import wraps
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, Optional
 
 import aiosqlite
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
 
 
 class ToolExecutionError(Exception):
@@ -619,10 +619,4 @@ class ToolManager:
 
         setattr(self, func.__name__, func)
         return {"name": func.__name__, "code": code}
-
-    async def close(self) -> None:
-        """Close the database connection asynchronously."""
-        if self.db_connection:
-            await self.db_connection.close()
-            self.db_connection = None
 


### PR DESCRIPTION
## Summary
- clean up unused imports and duplicate methods
- fix path imports for tests
- remove redundant cv2 import

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871a1f19c14832ca7d276691cae6f3e