### PR TITLE
Add WebSocket event streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ uvicorn main:app --reload
 ```
 This runs the minimal API defined in `main.py`.
 
+## API usage
+`api.py` exposes REST endpoints and WebSockets. To stream agent thoughts and tool
+outputs connect to `/agent/events` and send a JSON object with a `query` field.
+
+```python
+from websockets.sync.client import connect
+import json
+
+with connect("ws://localhost:8000/agent/events") as ws:
+    ws.send(json.dumps({"query": "hello"}))
+    print(ws.recv())  # first chunk
+```
+
 ## Testing
 Execute unit tests using `pytest`:
 ```bash

--- a/api.py
+++ b/api.py
@@ -5,13 +5,15 @@ from typing import Any, AsyncGenerator, Dict
 import asyncio
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel
+from tool_manager import ToolManager
 
 
 class CappuccinoAgent:
     """Minimal asynchronous CappuccinoAgent stub."""
 
-    def __init__(self) -> None:
+    def __init__(self, tool_manager: ToolManager) -> None:
         self._status = "idle"
+        self.tool_manager = tool_manager
 
     async def run(self, query: str) -> Dict[str, Any]:
         self._status = "running"
@@ -34,8 +36,19 @@ class CappuccinoAgent:
             yield f"chunk {i} for {query}"
         self._status = "completed"
 
+    async def stream_events(self, query: str) -> AsyncGenerator[str, None]:
+        """Yield thoughts and tool outputs as discrete text chunks."""
+        self._status = "streaming"
+        for i in range(2):
+            await asyncio.sleep(0.05)
+            yield f"thought {i}: {query}"
+        tool_result = await self.tool_manager.message_notify_user("ws", query)
+        yield f"tool_output: {tool_result['message']}"
+        self._status = "completed"
 
-agent = CappuccinoAgent()
+
+tool_manager = ToolManager(db_path=":memory:")
+agent = CappuccinoAgent(tool_manager)
 app = FastAPI()
 
 
@@ -69,6 +82,18 @@ async def agent_stream(websocket: WebSocket) -> None:
     try:
         query = await websocket.receive_text()
         async for chunk in agent.stream_responses(query):
+            await websocket.send_text(chunk)
+    except WebSocketDisconnect:
+        pass
+
+
+@app.websocket("/agent/events")
+async def agent_events(websocket: WebSocket) -> None:
+    await websocket.accept()
+    try:
+        data = await websocket.receive_json()
+        query = data.get("query", "")
+        async for chunk in agent.stream_events(query):
             await websocket.send_text(chunk)
     except WebSocketDisconnect:
         pass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,3 +17,20 @@ async def test_run_endpoint(monkeypatch):
     resp = client.post("/agent/run", json={"query": "hello"})
     assert resp.status_code == 200
     assert resp.json()["result"] == "ok"
+
+
+def test_websocket_events(monkeypatch):
+    async def fake_stream(self, query):
+        for i in range(2):
+            yield f"thought {i}"
+        yield "tool_output:done"
+
+    monkeypatch.setattr(api.CappuccinoAgent, "stream_events", fake_stream)
+    client = TestClient(api.app)
+    with client.websocket_connect("/agent/events") as ws:
+        ws.send_json({"query": "hi"})
+        data1 = ws.receive_text()
+        data2 = ws.receive_text()
+        data3 = ws.receive_text()
+    assert data1 == "thought 0"
+    assert data3 == "tool_output:done"


### PR DESCRIPTION
## Summary
- add ToolManager instance to the API and stream events over WebSocket
- document streaming API usage
- test WebSocket interactions with TestClient

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871a2d60138832c9e13ea48c595d4aa