### PR TITLE
Implement emotion recognition in LLM calls

### DIFF
--- a/cappuccino_agent.py
+++ b/cappuccino_agent.py
@@ -94,22 +94,34 @@ class CappuccinoAgent:
         await self.tool_manager.set_cached_result(key, value)
 
     async def call_llm(self, prompt: str) -> str:
-        """Call the LLM or fallback stub and cache the result."""
+        """Call the LLM with emotion context and cache the result."""
         cache_key = f"llm:{prompt}"
         cached = await self.get_cached_result(cache_key)
         if cached is not None:
             return cached
 
+        from emotion_recognizer import detect_emotion
+
+        emotion = detect_emotion(prompt)
+        prompt_with_emotion = f"{prompt}\n[User sentiment: {emotion}]"
+
         if self.llm:
-            resp = await self.llm(prompt)
-            result = resp if isinstance(resp, str) else resp.get("choices", [{}])[0].get("message", {}).get("content", "")
+            resp = await self.llm(prompt_with_emotion)
+            result = (
+                resp
+                if isinstance(resp, str)
+                else resp.get("choices", [{}])[0]
+                .get("message", {})
+                .get("content", "")
+            )
         elif self.client:
             response = await self.client.chat.completions.create(
                 model="gpt-4.1",
-                messages=[{"role": "user", "content": prompt}],
+                messages=[{"role": "user", "content": prompt_with_emotion}],
             )
             result = response.choices[0].message.content or ""
         else:
+            # Fallback stub preserves original behaviour for tests
             result = prompt[::-1]
 
         await self.set_cached_result(cache_key, result)

--- a/emotion_recognizer.py
+++ b/emotion_recognizer.py
@@ -1,0 +1,13 @@
+from textblob import TextBlob
+
+
+def detect_emotion(text: str) -> str:
+    """Return rough sentiment category for the given text."""
+    if not text:
+        return "neutral"
+    polarity = TextBlob(text).sentiment.polarity
+    if polarity > 0.1:
+        return "positive"
+    if polarity < -0.1:
+        return "negative"
+    return "neutral"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "openai",
     "fastapi",
     "python-dotenv",
+    "textblob",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest
 
 pytest-asyncio
 python-dotenv
+textblob

--- a/tests/test_emotion.py
+++ b/tests/test_emotion.py
@@ -1,0 +1,35 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from cappuccino_agent import CappuccinoAgent
+from tool_manager import ToolManager
+
+
+@pytest.mark.asyncio
+async def test_positive_prompt_includes_emotion():
+    captured = {}
+
+    async def fake_llm(prompt: str):
+        captured['prompt'] = prompt
+        return 'cheerful'
+
+    agent = CappuccinoAgent(llm=fake_llm, tool_manager=ToolManager(db_path=':memory:'))
+    result = await agent.call_llm('I love this product!')
+    assert result == 'cheerful'
+    assert 'positive' in captured['prompt']
+
+
+@pytest.mark.asyncio
+async def test_negative_prompt_includes_emotion():
+    captured = {}
+
+    async def fake_llm(prompt: str):
+        captured['prompt'] = prompt
+        return 'concerned'
+
+    agent = CappuccinoAgent(llm=fake_llm, tool_manager=ToolManager(db_path=':memory:'))
+    result = await agent.call_llm('I hate everything.')
+    assert result == 'concerned'
+    assert 'negative' in captured['prompt']


### PR DESCRIPTION
## Summary
- implement `emotion_recognizer.detect_emotion` using TextBlob
- include detected sentiment in `CappuccinoAgent.call_llm`
- ensure default behaviour unchanged when no LLM is configured
- install TextBlob as dependency
- test sentiment integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871a2d380e4832c901581848b812247