### PR TITLE
Add fractal planner

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,11 +4,16 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
 @dataclass
 class Settings:
     """Application configuration loaded from environment variables."""
+
     openai_api_key: str = os.getenv("OPENAI_API_KEY", "")
     anthropic_api_key: str | None = os.getenv("ANTHROPIC_API_KEY")
     azure_openai_key: str | None = os.getenv("AZURE_OPENAI_API_KEY")
+    fractal_depth: int = int(os.getenv("FRACTAL_DEPTH", "2"))
+    fractal_breadth: int = int(os.getenv("FRACTAL_BREADTH", "3"))
+
 
 settings = Settings()

--- a/fractal_planner.py
+++ b/fractal_planner.py
@@ -1,0 +1,30 @@
+from typing import Any, Dict, List, Optional
+
+from config import settings
+from planner import Planner as BasicPlanner
+
+
+class FractalPlanner:
+    """Recursive planner breaking tasks into hierarchical substeps."""
+
+    def __init__(
+        self,
+        depth: int | None = None,
+        breadth: int | None = None,
+        base_planner: Optional[BasicPlanner] = None,
+    ) -> None:
+        self.depth = depth if depth is not None else settings.fractal_depth
+        self.breadth = breadth if breadth is not None else settings.fractal_breadth
+        self.base_planner = base_planner or BasicPlanner()
+
+    def _search(self, context: str, depth: int) -> List[Dict[str, Any]]:
+        steps = self.base_planner.create_plan(context)[: self.breadth]
+        if depth <= 1:
+            return steps
+        for step in steps:
+            step["substeps"] = self._search(step["action"], depth - 1)
+        return steps
+
+    def create_plan(self, context: str) -> List[Dict[str, Any]]:
+        """Generate a hierarchical plan using recursive expansion."""
+        return self._search(context, self.depth)

--- a/planner.py
+++ b/planner.py
@@ -1,14 +1,30 @@
 from typing import Any, Dict, List
 
+from config import settings
+
+
 class Planner:
-    """Generate simple multi-step plans from user context."""
+    """Generate plans from user context using selectable strategy."""
 
-    def create_plan(self, context: str) -> List[Dict[str, Any]]:
-        """Create a list of steps derived from the context string.
+    def __init__(
+        self,
+        mode: str = "basic",
+        *,
+        fractal_depth: int | None = None,
+        fractal_breadth: int | None = None,
+    ) -> None:
+        self.mode = mode
+        if self.mode == "fractal":
+            from fractal_planner import FractalPlanner
 
-        The current implementation simply splits the context by periods and
-        returns non-empty segments as sequential steps.
-        """
+            self._planner = FractalPlanner(
+                depth=fractal_depth or settings.fractal_depth,
+                breadth=fractal_breadth or settings.fractal_breadth,
+            )
+        else:
+            self._planner = None
+
+    def _basic_plan(self, context: str) -> List[Dict[str, Any]]:
         steps = []
         for idx, part in enumerate(context.split(".")):
             item = part.strip()
@@ -17,3 +33,9 @@ class Planner:
         if not steps:
             steps.append({"step": 1, "action": context.strip()})
         return steps
+
+    def create_plan(self, context: str) -> List[Dict[str, Any]]:
+        """Create a plan based on the configured mode."""
+        if self.mode == "fractal" and self._planner is not None:
+            return self._planner.create_plan(context)
+        return self._basic_plan(context)

--- a/tests/test_fractal_planner.py
+++ b/tests/test_fractal_planner.py
@@ -1,0 +1,26 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from planner import Planner
+from fractal_planner import FractalPlanner
+
+
+def test_fractal_planner_nested():
+    planner = FractalPlanner(depth=2, breadth=2)
+    plan = planner.create_plan("collect data. analyze results")
+    assert len(plan) == 2
+    assert "substeps" in plan[0]
+    assert isinstance(plan[0]["substeps"], list)
+
+
+def test_planner_modes_basic_vs_fractal():
+    ctx = "step one. step two"
+    basic = Planner()
+    fractal = Planner(mode="fractal", fractal_depth=2, fractal_breadth=2)
+    basic_plan = basic.create_plan(ctx)
+    fractal_plan = fractal.create_plan(ctx)
+    assert len(basic_plan) == 2
+    assert len(fractal_plan) == 2
+    assert "substeps" in fractal_plan[0]


### PR DESCRIPTION
## Summary
- implement recursive `FractalPlanner`
- allow `Planner` to switch modes between basic and fractal
- add depth/breadth settings in configuration
- cover recursive planner with new tests

## Testing
- `ruff check config.py planner.py fractal_planner.py tests/test_fractal_planner.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871a2d00e38832c808a60d04d185a98