### PR TITLE
Add multimedia tool functions

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -19,6 +19,48 @@ TOOLS_SCHEMA: List[Dict] = [
     {
         "type": "function",
         "function": {
+            "name": "media_analyze_image",
+            "description": "Extract text from an image using OCR.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "image_path": {"type": "string"}
+                },
+                "required": ["image_path"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "media_recognize_speech",
+            "description": "Transcribe speech from an audio file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "audio_path": {"type": "string"}
+                },
+                "required": ["audio_path"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "media_describe_video",
+            "description": "Return the average color of the first frame of a video.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "video_path": {"type": "string"}
+                },
+                "required": ["video_path"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "info_search_image",
             "description": "Search images using the Unsplash API.",
             "parameters": {

--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -151,3 +151,69 @@ async def test_shell_wait_no_session(caplog):
     assert any("shell_wait" in r.getMessage() for r in caplog.records)
     assert "error" in result
 
+
+@pytest.mark.asyncio
+async def test_media_analyze_image(monkeypatch):
+    tm = ToolManager(db_path=":memory:")
+
+    import types, sys
+    pytesseract = types.SimpleNamespace(image_to_string=lambda img: "text")
+    monkeypatch.setitem(sys.modules, "pytesseract", pytesseract)
+    monkeypatch.setattr("PIL.Image.open", lambda p: "img")
+
+    result = await tm.media_analyze_image("img.png")
+    assert result["text"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_media_recognize_speech(monkeypatch):
+    tm = ToolManager(db_path=":memory:")
+
+    import types, sys
+
+    class DummyAudioFile:
+        def __init__(self, path):
+            self.path = path
+        def __enter__(self):
+            return "src"
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    class DummyRecognizer:
+        def record(self, source):
+            return b"aud"
+        def recognize_sphinx(self, audio):
+            return "hello"
+
+    speech_mod = types.SimpleNamespace(AudioFile=DummyAudioFile, Recognizer=DummyRecognizer)
+    monkeypatch.setitem(sys.modules, "speech_recognition", speech_mod)
+
+    result = await tm.media_recognize_speech("sound.wav")
+    assert result["text"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_media_describe_video(monkeypatch):
+    tm = ToolManager(db_path=":memory:")
+
+    class DummyFrame:
+        def mean(self, axis=None):
+            return [1.0, 2.0, 3.0]
+
+    class DummyCap:
+        def __init__(self, path):
+            self.path = path
+        def isOpened(self):
+            return True
+        def read(self):
+            return True, DummyFrame()
+        def release(self):
+            pass
+
+    import types, sys
+    cv2_mod = types.SimpleNamespace(VideoCapture=lambda path: DummyCap(path))
+    monkeypatch.setitem(sys.modules, "cv2", cv2_mod)
+
+    result = await tm.media_describe_video("video.mp4")
+    assert result["avg_color"] == [1.0, 2.0, 3.0]
+

--- a/tests/test_tool_manager_all.py
+++ b/tests/test_tool_manager_all.py
@@ -64,13 +64,38 @@ async def test_file_operations(tm, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_media_functions(tm, tmp_path):
+async def test_media_functions(tm, tmp_path, monkeypatch):
     img_path = tmp_path / "img.png"
     result = await tm.media_generate_image("hi", str(img_path))
     assert os.path.exists(result["path"])
     speech = await tm.media_generate_speech("hi", "out.wav")
     assert "error" in speech
 
+    import types, sys
+    monkeypatch.setitem(sys.modules, "pytesseract", types.SimpleNamespace(image_to_string=lambda img: "ocr"))
+    monkeypatch.setattr("PIL.Image.open", lambda p: "img")
+    ocr = await tm.media_analyze_image(str(img_path))
+    assert ocr["text"] == "ocr"
+    class DummyFile:
+        def __init__(self, path):
+            self.path = path
+        def __enter__(self):
+            return "src"
+        def __exit__(self, exc_type, exc, tb):
+            pass
+    class DummyRec:
+        def record(self, source):
+            return b"aud"
+        def recognize_sphinx(self, audio):
+            return "hi"
+    speech_mod = types.SimpleNamespace(AudioFile=DummyFile, Recognizer=DummyRec)
+    monkeypatch.setitem(sys.modules, "speech_recognition", speech_mod)
+    recog = await tm.media_recognize_speech("snd.wav")
+    assert recog["text"] == "hi"
+    cv2_mod = types.SimpleNamespace(VideoCapture=lambda p: types.SimpleNamespace(isOpened=lambda: True, read=lambda: (True, types.SimpleNamespace(mean=lambda axis=None: [1,2,3])), release=lambda: None))
+    monkeypatch.setitem(sys.modules, "cv2", cv2_mod)
+    desc = await tm.media_describe_video("v.mp4")
+    assert desc["avg_color"] == [1,2,3]
 
 @pytest.mark.asyncio
 async def test_info_search(tm, monkeypatch):
@@ -139,3 +164,4 @@ async def test_slide_functions(tm, tmp_path):
     assert os.path.exists(init["project"])
     present = await tm.slide_present(str(proj))
     assert present["status"] == "presenting"
+

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -376,6 +376,63 @@ class ToolManager:
             return {"error": "speech generation not implemented"}
 
 
+
+    @log_tool
+    async def media_analyze_image(self, image_path: str) -> Dict[str, Any]:
+        """Extract text from an image using pytesseract."""
+        try:
+            import pytesseract
+            from PIL import Image
+        except Exception:
+            return {"error": "pytesseract not available"}
+
+        def _ocr() -> Dict[str, Any]:
+            text = pytesseract.image_to_string(Image.open(image_path))
+            return {"text": text}
+
+        return await asyncio.to_thread(_ocr)
+
+    @log_tool
+    async def media_recognize_speech(self, audio_path: str) -> Dict[str, Any]:
+        """Transcribe speech from an audio file using SpeechRecognition."""
+        try:
+            import speech_recognition as sr
+        except Exception:
+            return {"error": "speech_recognition not available"}
+
+        def _recognize() -> Dict[str, Any]:
+            recognizer = sr.Recognizer()
+            with sr.AudioFile(audio_path) as source:
+                audio = recognizer.record(source)
+            try:
+                text = recognizer.recognize_sphinx(audio)
+            except Exception:
+                return {"error": "recognition failed"}
+            return {"text": text}
+
+        return await asyncio.to_thread(_recognize)
+
+    @log_tool
+    async def media_describe_video(self, video_path: str) -> Dict[str, Any]:
+        """Return the average color of the first frame of a video."""
+        try:
+            import cv2
+        except Exception:
+            return {"error": "opencv not available"}
+
+        def _describe() -> Dict[str, Any]:
+            cap = cv2.VideoCapture(video_path)
+            if not cap.isOpened():
+                raise ValueError("unable to open video")
+            ret, frame = cap.read()
+            cap.release()
+            if not ret:
+                raise ValueError("unable to read frame")
+            avg_color = frame.mean(axis=(0, 1))
+            return {"avg_color": [float(x) for x in avg_color]}
+
+        return await asyncio.to_thread(_describe)
+
     async def media_analyze_video(self, video_path: str) -> Dict[str, Any]:
         """Return basic metadata for a video file."""
         try:


### PR DESCRIPTION
## Summary
- add async OCR, speech recognition and video description tools
- expose these new tools in tools schema
- test new ToolManager functions and update integration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871a2d2d938832cb9fc9b2cdf3cb559