### PR TITLE
Add LLM tool calling support

### DIFF
--- a/api.py
+++ b/api.py
@@ -13,15 +13,13 @@ from tool_manager import ToolManager
 from cappuccino_agent import CappuccinoAgent
 
 
-    async def stream_events(self, query: str) -> AsyncGenerator[str, None]:
-        """Yield thoughts and tool outputs as discrete text chunks."""
-        self._status = "streaming"
-        for i in range(2):
-            await asyncio.sleep(0.05)
-            yield f"thought {i}: {query}"
-        tool_result = await self.tool_manager.message_notify_user("ws", query)
-        yield f"tool_output: {tool_result['message']}"
-        self._status = "completed"
+async def stream_events(query: str) -> AsyncGenerator[str, None]:
+    """Yield thoughts and tool outputs as discrete text chunks."""
+    for i in range(2):
+        await asyncio.sleep(0.05)
+        yield f"thought {i}: {query}"
+    tool_result = await tool_manager.message_notify_user("ws", query)
+    yield f"tool_output: {tool_result['message']}"
 
 
 tool_manager = ToolManager(db_path=":memory:")

--- a/cappuccino_agent.py
+++ b/cappuccino_agent.py
@@ -169,6 +169,79 @@ class CappuccinoAgent:
         await self.set_cached_result(cache_key, result)
         return result
 
+    async def call_llm_with_tools(
+        self,
+        prompt: str,
+        tools_schema: List[Dict[str, Any]],
+    ) -> str:
+        """Call the LLM using function calling with the provided tools."""
+        messages: List[Dict[str, Any]] = [
+            {"role": "user", "content": prompt}
+        ]
+
+        if not self.client:
+            # Fallback for tests without an OpenAI client
+            return await self.call_llm(prompt)
+
+        response = await self.client.chat.completions.create(
+            model="gpt-4.1",
+            messages=messages,
+            tools=tools_schema,
+        )
+
+        message = response.choices[0].message
+        if message.tool_calls:
+            tool_calls_payload = []
+            for tc in message.tool_calls:
+                if hasattr(tc, "model_dump"):
+                    tool_calls_payload.append(tc.model_dump())
+                else:
+                    tool_calls_payload.append(
+                        {
+                            "id": getattr(tc, "id", ""),
+                            "function": {
+                                "name": tc.function.name,
+                                "arguments": tc.function.arguments,
+                            },
+                            "type": "function",
+                        }
+                    )
+
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": message.content or "",
+                    "tool_calls": tool_calls_payload,
+                }
+            )
+            for tool_call in message.tool_calls:
+                func_name = tool_call.function.name
+                try:
+                    args = json.loads(tool_call.function.arguments or "{}")
+                except Exception:
+                    args = {}
+                if hasattr(self.tool_manager, func_name):
+                    func = getattr(self.tool_manager, func_name)
+                    result = await func(**args)
+                else:
+                    result = {"error": f"tool {func_name} not found"}
+
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "content": json.dumps(result),
+                    }
+                )
+
+            followup = await self.client.chat.completions.create(
+                model="gpt-4.1",
+                messages=messages,
+            )
+            return followup.choices[0].message.content or ""
+
+        return message.content or ""
+
     async def _add_message(
         self,
         role: str,

--- a/state_manager.py
+++ b/state_manager.py
@@ -147,6 +147,3 @@ class StateManager:
             (graph.to_json(),),
         )
         await conn.commit()
-
-        )
-        await conn.commit()

--- a/tests/test_llm_tools.py
+++ b/tests/test_llm_tools.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from cappuccino_agent import CappuccinoAgent
+from tool_manager import ToolManager, log_tool
+
+class DummyToolManager(ToolManager):
+    def __init__(self):
+        super().__init__(db_path=":memory:")
+        self.called = False
+
+    @log_tool
+    async def dummy_tool(self, x: int) -> dict:
+        self.called = True
+        return {"x": x + 1}
+
+class DummyClient:
+    def __init__(self):
+        self.calls = 0
+        self.chat = self.Chat(self)
+
+    class Chat:
+        def __init__(self, outer):
+            self.completions = outer.Completions(outer)
+
+    class Completions:
+        def __init__(self, outer):
+            self.outer = outer
+        async def create(self, model, messages, tools=None):
+            self.outer.calls += 1
+            if self.outer.calls == 1:
+                class F:
+                    name = "dummy_tool"
+                    arguments = "{\"x\": 3}"
+                class TC:
+                    id = "1"
+                    function = F()
+                class M:
+                    content = None
+                    tool_calls = [TC()]
+                class R:
+                    choices = [type("C", (), {"message": M()})]
+                return R()
+            else:
+                class M:
+                    content = "done"
+                    tool_calls = None
+                class R:
+                    choices = [type("C", (), {"message": M()})]
+                return R()
+
+@pytest.mark.asyncio
+async def test_call_llm_with_tools(monkeypatch):
+    tm = DummyToolManager()
+    agent = CappuccinoAgent(tool_manager=tm, llm=None)
+    agent.client = DummyClient()
+    schema = [{
+        "type": "function",
+        "function": {
+            "name": "dummy_tool",
+            "description": "dummy",
+            "parameters": {
+                "type": "object",
+                "properties": {"x": {"type": "integer"}},
+                "required": ["x"],
+            },
+        },
+    }]
+    out = await agent.call_llm_with_tools("hi", schema)
+    assert out == "done"
+    assert tm.called


### PR DESCRIPTION
## Summary
- implement `call_llm_with_tools` for handling OpenAI function calls
- fix minor bug in `state_manager.save_graph`
- provide simple `stream_events` helper in API module
- add unit test covering new tool calling functionality

## Testing
- `pytest tests/test_llm_tools.py::test_call_llm_with_tools -q`
- `pytest -q` *(fails: Interrupted: 2 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6871b39bf828832cbff565c0841da0a4