### PR TITLE
Fix lint issues flagged by ruff

### DIFF
--- a/agents/executor_agent.py
+++ b/agents/executor_agent.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Dict
+from typing import Any
 
 from tool_manager import ToolManager
 

--- a/api.py
+++ b/api.py
@@ -11,10 +11,9 @@ from planner import Planner
 from state_manager import StateManager
 from goal_manager import GoalManager
 from tool_manager import ToolManager
+from cappuccino_agent import CappuccinoAgent
 
 openai_client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY", "test"))
-
-from cappuccino_agent import CappuccinoAgent
 
 
 async def stream_events(query: str) -> AsyncGenerator[str, None]:

--- a/discord_manager.py
+++ b/discord_manager.py
@@ -7,7 +7,6 @@ import discord
 from discord.ext import commands
 import asyncio
 import logging
-import json
 from typing import Any, Dict, List, Optional, Callable
 from datetime import datetime
 import threading

--- a/discord_tools.py
+++ b/discord_tools.py
@@ -4,7 +4,7 @@ Provides tools for Discord interactions through the ToolManager.
 """
 
 import asyncio
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 from discord_manager import DiscordManager
 import logging
 import os

--- a/docker_manager.py
+++ b/docker_manager.py
@@ -4,12 +4,11 @@ Provides isolated execution environments for code execution and system operation
 """
 
 import docker
-import json
 import logging
 import os
 import tempfile
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict
 from pathlib import Path
 
 logger = logging.getLogger(__name__)

--- a/knowledge_graph.py
+++ b/knowledge_graph.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Tuple
+from typing import Any, List, Tuple
 
 import networkx as nx
 from networkx.readwrite import json_graph

--- a/test_integration.py
+++ b/test_integration.py
@@ -302,7 +302,7 @@ for pkg in sorted(pkg_resources.working_set, key=lambda x: x.project_name):
             "detailed_results": self.test_results
         }
         
-        logger.info(f"=== Test Summary ===")
+        logger.info("=== Test Summary ===")
         logger.info(f"Overall: {'PASS' if overall_success else 'FAIL'}")
         logger.info(f"Tests: {passed_tests}/{total_tests} passed")
         logger.info(f"Duration: {duration:.2f} seconds")

--- a/tests/agents/test_analyzer_agent.py
+++ b/tests/agents/test_analyzer_agent.py
@@ -1,4 +1,5 @@
-import sys, pathlib
+import sys
+import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
 import asyncio

--- a/tests/agents/test_executor_agent.py
+++ b/tests/agents/test_executor_agent.py
@@ -1,4 +1,5 @@
-import sys, pathlib
+import sys
+import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
 import asyncio

--- a/tests/agents/test_planner_agent.py
+++ b/tests/agents/test_planner_agent.py
@@ -1,4 +1,5 @@
-import sys, pathlib
+import sys
+import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
 import asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,7 +32,7 @@ def test_websocket_events(monkeypatch):
     with client.websocket_connect("/agent/events") as ws:
         ws.send_json({"query": "hi"})
         data1 = ws.receive_text()
-        data2 = ws.receive_text()
+        _ = ws.receive_text()
         data3 = ws.receive_text()
     assert data1 == "thought 0"
     assert data3 == "tool_output:done"

--- a/tests/test_emotion.py
+++ b/tests/test_emotion.py
@@ -1,4 +1,5 @@
-import sys, pathlib
+import sys
+import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import pytest

--- a/tests/test_goal_plan.py
+++ b/tests/test_goal_plan.py
@@ -1,4 +1,5 @@
-import sys, pathlib
+import sys
+import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import pytest

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,4 +1,7 @@
-import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import pytest
 
 from tool_manager import ToolManager

--- a/tests/test_self_improver.py
+++ b/tests/test_self_improver.py
@@ -1,4 +1,5 @@
-import sys, pathlib
+import sys
+import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import pytest

--- a/tests/test_tool_autogen.py
+++ b/tests/test_tool_autogen.py
@@ -1,5 +1,4 @@
 import sys
-import sys
 import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import subprocess

--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -8,7 +8,7 @@ import os
 import logging
 import pytest
 
-from tool_manager import ToolManager, ToolExecutionError
+from tool_manager import ToolManager
 import cv2
 
 @pytest.mark.asyncio
@@ -152,7 +152,8 @@ async def test_shell_wait_no_session(caplog):
 async def test_media_analyze_image(monkeypatch):
     tm = ToolManager(db_path=":memory:")
 
-    import types, sys
+    import types
+    import sys
     pytesseract = types.SimpleNamespace(image_to_string=lambda img: "text")
     monkeypatch.setitem(sys.modules, "pytesseract", pytesseract)
     monkeypatch.setattr("PIL.Image.open", lambda p: "img")
@@ -165,7 +166,8 @@ async def test_media_analyze_image(monkeypatch):
 async def test_media_recognize_speech(monkeypatch):
     tm = ToolManager(db_path=":memory:")
 
-    import types, sys
+    import types
+    import sys
 
     class DummyAudioFile:
         def __init__(self, path):
@@ -206,7 +208,8 @@ async def test_media_describe_video(monkeypatch):
         def release(self):
             pass
 
-    import types, sys
+    import types
+    import sys
     cv2_mod = types.SimpleNamespace(VideoCapture=lambda path: DummyCap(path))
     monkeypatch.setitem(sys.modules, "cv2", cv2_mod)
 

--- a/tests/test_tool_manager_all.py
+++ b/tests/test_tool_manager_all.py
@@ -73,7 +73,8 @@ async def test_media_functions(tm, tmp_path, monkeypatch):
     speech = await tm.media_generate_speech("hi", "out.wav")
     assert "error" in speech
 
-    import types, sys
+    import types
+    import sys
     monkeypatch.setitem(sys.modules, "pytesseract", types.SimpleNamespace(image_to_string=lambda img: "ocr"))
     monkeypatch.setattr("PIL.Image.open", lambda p: "img")
     ocr = await tm.media_analyze_image(str(img_path))

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -11,11 +11,9 @@ from functools import wraps
 from typing import Any, Dict, Optional
 
 import aiosqlite
-from PIL import Image, ImageDraw, ImageFont
-from knowledge_graph import KnowledgeGraph
+from PIL import Image, ImageDraw
 from state_manager import StateManager
 
-from PIL import Image, ImageDraw
 
 
 class ToolExecutionError(Exception):
@@ -738,7 +736,7 @@ class ToolManager:
         raw_code = textwrap.dedent(response.choices[0].message.content or "")
         lines = raw_code.splitlines()
         if len(lines) > 1 and not lines[1].startswith(" "):
-            lines[1:] = ["    " + l for l in lines[1:]]
+            lines[1:] = ["    " + line for line in lines[1:]]
         code = "\n".join(lines)
 
         match = re.search(r"async def\s+(\w+)\s*\(", code)


### PR DESCRIPTION
## Summary
- reorder imports and remove unused imports
- fix `logger.info` string
- split multiple imports into separate lines
- rename ambiguous variable
- ignore intermediate websocket response in `tests/test_api.py`

## Testing
- `ruff check .`
- `pytest -q` *(fails: Docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_6871ca74d8bc832c882b3ef540c9ab37