### PR TITLE
Handle missing Docker daemon in tests

### DIFF
--- a/test_integration.py
+++ b/test_integration.py
@@ -9,8 +9,16 @@ import time
 import logging
 from typing import Dict, Any
 
+import pytest
+
 # Add current directory to path for imports
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+docker = pytest.importorskip("docker")
+try:
+    docker.from_env()
+except docker.errors.DockerException:
+    pytest.skip("Docker daemon not available")
 
 from docker_tools import DOCKER_TOOLS
 from discord_tools import DISCORD_TOOLS


### PR DESCRIPTION
## Summary
- skip integration tests when Docker isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871cebdd2f0832c83e3d0cf8222b813