### PR TITLE
Update README about integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,16 @@ with connect("ws://localhost:8000/agent/events") as ws:
 ```
 
 ## Testing
-Execute unit tests using `pytest`:
+Install the project dependencies and run the unit tests with `pytest`:
 ```bash
+pip install -r requirements.txt
 pytest -q
 ```
+
+The integration script `test_integration.py` exercises Docker and Discord
+features. It requires a running Docker daemon and a valid `DISCORD_BOT_TOKEN`
+environment variable in order to fully execute. If these requirements are
+missing, the integration tests are skipped while the other unit tests still run.
 
 ## Design philosophy
 Key principles from `AGENTS.md`:


### PR DESCRIPTION
## Summary
- clarify unit testing instructions
- note Docker daemon and DISCORD_BOT_TOKEN requirement for `test_integration.py`
- explain that integration tests skip if requirements are missing

## Testing
- `pip install -r requirements.txt`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6871cebdca2c832c9dfd7e6244203ec1