### PR TITLE
Add Responses API integration

### DIFF
--- a/cappuccino_agent.py
+++ b/cappuccino_agent.py
@@ -174,15 +174,54 @@ class CappuccinoAgent:
         prompt: str,
         tools_schema: List[Dict[str, Any]],
     ) -> str:
-        """Call the LLM using function calling with the provided tools."""
-        messages: List[Dict[str, Any]] = [
-            {"role": "user", "content": prompt}
-        ]
+        """Call the LLM using built-in tools via the Responses API if available."""
+
+        messages: List[Dict[str, Any]] = [{"role": "user", "content": prompt}]
 
         if not self.client:
             # Fallback for tests without an OpenAI client
             return await self.call_llm(prompt)
 
+        if hasattr(self.client, "responses"):
+            # New Responses API with built-in tools
+            first = await self.client.responses.create(
+                model="gpt-4.1",
+                input=messages,
+                tools=tools_schema,
+            )
+
+            for item in getattr(first, "output", []):
+                if getattr(item, "type", "") == "function_call":
+                    func_name = getattr(item, "name", "")
+                    try:
+                        args = json.loads(getattr(item, "arguments", "{}") or "{}")
+                    except Exception:
+                        args = {}
+                    if hasattr(self.tool_manager, func_name):
+                        func = getattr(self.tool_manager, func_name)
+                        result = await func(**args)
+                    else:
+                        result = {"error": f"tool {func_name} not found"}
+
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": getattr(item, "call_id", ""),
+                            "content": json.dumps(result),
+                        }
+                    )
+
+            followup = await self.client.responses.create(
+                model="gpt-4.1",
+                input=messages,
+            )
+
+            for out in getattr(followup, "output", []):
+                if getattr(out, "type", "") == "text":
+                    return getattr(out, "text", "")
+            return ""
+
+        # Fallback to Chat Completions function-calling
         response = await self.client.chat.completions.create(
             model="gpt-4.1",
             messages=messages,
@@ -191,29 +230,6 @@ class CappuccinoAgent:
 
         message = response.choices[0].message
         if message.tool_calls:
-            tool_calls_payload = []
-            for tc in message.tool_calls:
-                if hasattr(tc, "model_dump"):
-                    tool_calls_payload.append(tc.model_dump())
-                else:
-                    tool_calls_payload.append(
-                        {
-                            "id": getattr(tc, "id", ""),
-                            "function": {
-                                "name": tc.function.name,
-                                "arguments": tc.function.arguments,
-                            },
-                            "type": "function",
-                        }
-                    )
-
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": message.content or "",
-                    "tool_calls": tool_calls_payload,
-                }
-            )
             for tool_call in message.tool_calls:
                 func_name = tool_call.function.name
                 try:

--- a/tests/test_llm_tools.py
+++ b/tests/test_llm_tools.py
@@ -20,37 +20,28 @@ class DummyToolManager(ToolManager):
 class DummyClient:
     def __init__(self):
         self.calls = 0
-        self.chat = self.Chat(self)
+        self.responses = self.Responses(self)
 
-    class Chat:
-        def __init__(self, outer):
-            self.completions = outer.Completions(outer)
-
-    class Completions:
+    class Responses:
         def __init__(self, outer):
             self.outer = outer
-        async def create(self, model, messages, tools=None):
+
+        async def create(self, model, input=None, tools=None):
             self.outer.calls += 1
             if self.outer.calls == 1:
-                class F:
+                class Out:
+                    type = "function_call"
                     name = "dummy_tool"
                     arguments = "{\"x\": 3}"
-                class TC:
-                    id = "1"
-                    function = F()
-                class M:
-                    content = None
-                    tool_calls = [TC()]
-                class R:
-                    choices = [type("C", (), {"message": M()})]
-                return R()
+                    call_id = "1"
+
+                return type("Resp", (), {"output": [Out()]})()
             else:
-                class M:
-                    content = "done"
-                    tool_calls = None
-                class R:
-                    choices = [type("C", (), {"message": M()})]
-                return R()
+                class Out:
+                    type = "text"
+                    text = "done"
+
+                return type("Resp", (), {"output": [Out()]})()
 
 @pytest.mark.asyncio
 async def test_call_llm_with_tools(monkeypatch):


### PR DESCRIPTION
## Summary
- hook into new OpenAI Responses API for tool calling
- update LLM tool call test to use the new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ef380ba4832c96d2034a52c25ac3