### PR TITLE
Fix import order in integration test

### DIFF
--- a/test_integration.py
+++ b/test_integration.py
@@ -10,6 +10,8 @@ import logging
 from typing import Dict, Any
 
 import pytest
+from docker_tools import DOCKER_TOOLS
+from discord_tools import DISCORD_TOOLS
 
 # Add current directory to path for imports
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -19,9 +21,6 @@ try:
     docker.from_env()
 except docker.errors.DockerException:
     pytest.skip("Docker daemon not available")
-
-from docker_tools import DOCKER_TOOLS
-from discord_tools import DISCORD_TOOLS
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- move docker and discord tool imports to top of `test_integration.py`

## Testing
- `pytest tests/test_state_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6871fb22bf5c832cb34f88afadba8618