### PR TITLE
Remove dummy LLM stub and improve OpenAI error handling

### DIFF
--- a/agents/executor_agent.py
+++ b/agents/executor_agent.py
@@ -33,5 +33,5 @@ class ExecutorAgent:
                 else:
                     result = llm_result
             else:
-                result = action[::-1]
+                raise RuntimeError("No LLM client configured")
             await result_queue.put({"step": step.get("step"), "result": result})

--- a/api.py
+++ b/api.py
@@ -13,7 +13,7 @@ from goal_manager import GoalManager
 from tool_manager import ToolManager
 from cappuccino_agent import CappuccinoAgent
 
-openai_client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY", "test"))
+openai_client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 
 async def stream_events(query: str) -> AsyncGenerator[str, None]:

--- a/cappuccino_agent.py
+++ b/cappuccino_agent.py
@@ -157,14 +157,16 @@ class CappuccinoAgent:
                 .get("content", "")
             )
         elif self.client:
-            response = await self.client.chat.completions.create(
-                model="gpt-4.1",
-                messages=[{"role": "user", "content": prompt_with_emotion}],
-            )
-            result = response.choices[0].message.content or ""
+            try:
+                response = await self.client.chat.completions.create(
+                    model="gpt-4.1",
+                    messages=[{"role": "user", "content": prompt_with_emotion}],
+                )
+                result = response.choices[0].message.content or ""
+            except Exception as exc:
+                raise RuntimeError(f"LLM request failed: {exc}")
         else:
-            # Fallback stub preserves original behaviour for tests
-            result = prompt[::-1]
+            raise RuntimeError("No LLM client configured")
 
         await self.set_cached_result(cache_key, result)
         return result
@@ -179,16 +181,18 @@ class CappuccinoAgent:
         messages: List[Dict[str, Any]] = [{"role": "user", "content": prompt}]
 
         if not self.client:
-            # Fallback for tests without an OpenAI client
-            return await self.call_llm(prompt)
+            raise RuntimeError("No LLM client configured")
 
         if hasattr(self.client, "responses"):
             # New Responses API with built-in tools
-            first = await self.client.responses.create(
-                model="gpt-4.1",
-                input=messages,
-                tools=tools_schema,
-            )
+            try:
+                first = await self.client.responses.create(
+                    model="gpt-4.1",
+                    input=messages,
+                    tools=tools_schema,
+                )
+            except Exception as exc:
+                raise RuntimeError(f"LLM request failed: {exc}")
 
             for item in getattr(first, "output", []):
                 if getattr(item, "type", "") == "function_call":
@@ -211,10 +215,13 @@ class CappuccinoAgent:
                         }
                     )
 
-            followup = await self.client.responses.create(
-                model="gpt-4.1",
-                input=messages,
-            )
+            try:
+                followup = await self.client.responses.create(
+                    model="gpt-4.1",
+                    input=messages,
+                )
+            except Exception as exc:
+                raise RuntimeError(f"LLM request failed: {exc}")
 
             for out in getattr(followup, "output", []):
                 if getattr(out, "type", "") == "text":
@@ -222,11 +229,14 @@ class CappuccinoAgent:
             return ""
 
         # Fallback to Chat Completions function-calling
-        response = await self.client.chat.completions.create(
-            model="gpt-4.1",
-            messages=messages,
-            tools=tools_schema,
-        )
+        try:
+            response = await self.client.chat.completions.create(
+                model="gpt-4.1",
+                messages=messages,
+                tools=tools_schema,
+            )
+        except Exception as exc:
+            raise RuntimeError(f"LLM request failed: {exc}")
 
         message = response.choices[0].message
         if message.tool_calls:

--- a/docker_tools.py
+++ b/docker_tools.py
@@ -10,7 +10,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 # Global Docker manager instance
-docker_manager = DockerManager()
+try:
+    docker_manager = DockerManager()
+except Exception as exc:  # pragma: no cover - environment without Docker
+    docker_manager = None
+    logging.warning(f"DockerManager unavailable: {exc}")
 
 
 def container_create(image_name: str = None, container_name: str = "cappuccino-env", 

--- a/test_integration.py
+++ b/test_integration.py
@@ -10,17 +10,20 @@ import logging
 from typing import Dict, Any
 
 import pytest
-from docker_tools import DOCKER_TOOLS
-from discord_tools import DISCORD_TOOLS
 
 # Add current directory to path for imports
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 docker = pytest.importorskip("docker")
+discord = pytest.importorskip("discord")
+
 try:
     docker.from_env()
 except docker.errors.DockerException:
     pytest.skip("Docker daemon not available")
+
+from docker_tools import DOCKER_TOOLS
+from discord_tools import DISCORD_TOOLS
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+import pytest
+
+@pytest.fixture(autouse=True, scope="session")
+def _set_openai_key():
+    """Ensure OPENAI_API_KEY is available for tests."""
+    os.environ.setdefault("OPENAI_API_KEY", "test")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -18,8 +18,12 @@ async def test_cache_methods(tmp_path):
 @pytest.mark.asyncio
 async def test_agent_cache(tmp_path):
     tm = ToolManager(db_path=os.path.join(tmp_path, "db.sqlite"))
-    agent = CappuccinoAgent(tool_manager=tm)
+
+    async def fake_llm(text: str) -> str:
+        return "ok"
+
+    agent = CappuccinoAgent(tool_manager=tm, llm=fake_llm)
     response = await agent.call_llm("hello")
-    assert response == "olleh"
+    assert response == "ok"
     cached = await agent.get_cached_result("llm:hello")
-    assert cached == "olleh"
+    assert cached == "ok"

--- a/tests/test_cappuccino_agent.py
+++ b/tests/test_cappuccino_agent.py
@@ -12,11 +12,8 @@ from cappuccino_agent import CappuccinoAgent
 @pytest.mark.asyncio
 async def test_agent_runs_without_llm():
     agent = CappuccinoAgent(tool_manager=None, llm=None)
-    result = await agent.run("do this. then that")
-    assert result == [
-        {"step": 1, "result": "siht od"},
-        {"step": 2, "result": "taht neht"},
-    ]
+    with pytest.raises(RuntimeError):
+        await agent.run("do this. then that")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove fallback stubs returning reversed text
- prioritize OpenAI client and surface API errors
- make ExecutorAgent require an LLM client
- handle unavailable Docker in `docker_tools`
- update FastAPI initialization
- adjust tests for new behaviour and provide OPENAI_API_KEY during tests
- skip integration test if Docker/Discord unavailable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68720d207f18832c932042ee35a10a09