### PR TITLE
Add OpenAI-run endpoint and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,11 @@ Run a simple interactive chat loop from the terminal:
 python chat_cli.py
 ```
 Exit the session with `exit` or `quit`.
+
+## API CLI
+Use `agent_cli.py` to send a query to the `/agent/run` endpoint and save any
+generated images locally:
+
+```bash
+python agent_cli.py "青い空と白い雲の風景画"
+```

--- a/agent_cli.py
+++ b/agent_cli.py
@@ -1,0 +1,37 @@
+import requests
+import sys
+import base64
+import io
+from PIL import Image
+
+sys.stdout.reconfigure(encoding='utf-8')
+
+
+def main() -> None:
+    url = "http://163.43.113.161:8000/agent/run"
+    query = sys.argv[1] if len(sys.argv) > 1 else input("Query: ")
+
+    res = requests.post(url, json={"query": query})
+    res.raise_for_status()
+    result = res.json()
+
+    text_output = result.get("text", "")
+    if text_output:
+        print(text_output)
+
+    images = result.get("images", [])
+    if images:
+        for i, img_data_uri in enumerate(images):
+            try:
+                header, encoded = img_data_uri.split(",", 1)
+                binary_data = base64.b64decode(encoded)
+                image = Image.open(io.BytesIO(binary_data))
+                filename = f"generated_image_{i+1}.png"
+                image.save(filename)
+                print(f"画像{i+1}: {filename} に保存しました。")
+            except Exception as e:  # pragma: no cover - manual use
+                print(f"画像{i+1}の保存中にエラーが発生しました: {e}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    main()

--- a/api.py
+++ b/api.py
@@ -7,12 +7,14 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel
 import os
 from openai import AsyncOpenAI
+from dotenv import load_dotenv
 from planner import Planner
 from state_manager import StateManager
 from goal_manager import GoalManager
 from tool_manager import ToolManager
 from cappuccino_agent import CappuccinoAgent
 
+load_dotenv()
 openai_client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 
@@ -38,6 +40,39 @@ class RunRequest(BaseModel):
     query: str
 
 
+class RunResponse(BaseModel):
+    text: str
+    images: List[str]
+
+
+async def call_openai(prompt: str) -> Dict[str, List[str]]:
+    resp = await openai_client.responses.create(
+        model="gpt-4.1",
+        tools=[
+            {"type": "web_search_preview"},
+            {"type": "code_interpreter", "container": {"type": "auto"}},
+            {"type": "image_generation"},
+        ],
+        input=[{"role": "user", "content": prompt}],
+    )
+
+    text_blocks: List[str] = []
+    images: List[str] = []
+    for item in resp.output:
+        if item.type == "message":
+            for block in item.content:
+                if getattr(block, "type", "") in {"output_text", "text"}:
+                    txt = getattr(block, "text", "").strip()
+                    if txt:
+                        text_blocks.append(txt)
+        elif item.type == "image_generation_call":
+            img_data = getattr(item, "result", None)
+            if img_data:
+                images.append(f"data:image/png;base64,{img_data}")
+
+    return {"text": "\n\n".join(text_blocks), "images": images}
+
+
 class ToolCallResult(BaseModel):
     data: Dict[str, Any]
 
@@ -57,10 +92,9 @@ class RealtimeSessionParams(BaseModel):
     voice: str = "verse"
 
 
-@app.post("/agent/run")
-async def run_agent(request: RunRequest) -> Dict[str, Any]:
-    result = await agent.run(request.query)
-    return {"result": result}
+@app.post("/agent/run", response_model=RunResponse)
+async def run_agent(request: RunRequest) -> Dict[str, List[str]]:
+    return await call_openai(request.query)
 
 
 @app.get("/agent/status")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,14 +11,14 @@ import api
 
 @pytest.mark.asyncio
 async def test_run_endpoint(monkeypatch):
-    async def fake_run(self, query):
-        return "ok"
+    async def fake_call(prompt):
+        return {"text": "ok", "images": []}
 
-    monkeypatch.setattr(api.CappuccinoAgent, "run", fake_run)
+    monkeypatch.setattr(api, "call_openai", fake_call)
     client = TestClient(api.app)
     resp = client.post("/agent/run", json={"query": "hello"})
     assert resp.status_code == 200
-    assert resp.json()["result"] == "ok"
+    assert resp.json()["text"] == "ok"
 
 
 def test_websocket_events(monkeypatch):


### PR DESCRIPTION
## Summary
- update `api.py` with `call_openai` helper using `AsyncOpenAI`
- return generated text and images from `/agent/run`
- add simple command line client `agent_cli.py`
- document the new CLI usage
- adjust API tests for new endpoint behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68723aabb304832cb015a0fe47dfee92