### PR TITLE
Fix poker import

### DIFF
--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -12,7 +12,7 @@ from dotenv import load_dotenv
 from dataclasses import dataclass
 from typing import Any
 
-from poker import PokerMatch, PokerView
+from .poker import PokerMatch, PokerView
 
 
 # ───────────────── TOKEN / KEY ─────────────────


### PR DESCRIPTION
## Summary
- fix discord bot poker module import

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687245306044832c88d344e66f532c07