### PR TITLE
Fix GPT command to use Cappuccino API

### DIFF
--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -7,6 +7,7 @@ import tempfile
 import logging
 import datetime
 import asyncio
+import base64
 from discord import app_commands
 from cappuccino_agent import CappuccinoAgent
 import json
@@ -34,6 +35,7 @@ load_dotenv(os.path.join(ROOT_DIR, ".env"))
 # Load credentials from environment variables
 TOKEN = os.getenv("DISCORD_BOT_TOKEN", "")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+CAPP_API_URL = os.getenv("CAPP_API_URL", "http://163.43.113.161:8000/agent/run")
 
 
 NEWS_CONF_FILE = os.path.join(ROOT_DIR, "news_channel.json")
@@ -116,6 +118,27 @@ WEATHER_CHANNEL_ID = _load_weather_channel()
 
 # Initialize CappuccinoAgent for GPT interactions
 cappuccino_agent = CappuccinoAgent(api_key=OPENAI_API_KEY)
+
+async def call_cappuccino_api(prompt: str) -> tuple[str, list[discord.File]]:
+    """Send query to Cappuccino API and return text and image files."""
+    async with aiohttp.ClientSession() as sess:
+        async with sess.post(CAPP_API_URL, json={"query": prompt}, timeout=120) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+
+    text = data.get("text", "")
+    images = []
+    for i, img in enumerate(data.get("images", [])):
+        try:
+            _, b64 = img.split(",", 1)
+            binary = base64.b64decode(b64)
+            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+            tmp.write(binary)
+            tmp.close()
+            images.append(discord.File(tmp.name, filename=f"image_{i+1}.png"))
+        except Exception as e:
+            logger.error("failed to decode image: %s", e)
+    return text, images
 
 # ───────────────── Voice Transcription / TTS ─────────────────
 
@@ -1458,17 +1481,12 @@ async def cmd_gpt(msg: discord.Message, user_text: str):
 
     reply = await msg.reply("…")
     try:
-        tools_schema = [
-            {"type": "web_search_preview"},
-            {"type": "code_interpreter", "container": {"type": "auto"}},
-            {"type": "image_generation"},
-        ]
-        response = await cappuccino_agent.call_llm_with_tools(prompt, tools_schema)
+        response_text, files = await call_cappuccino_api(prompt)
     except Exception as exc:
         await reply.edit(content=f"Error: {exc}")
         return
 
-    await reply.edit(content=response[:1900])
+    await reply.edit(content=response_text[:1900], attachments=files or None)
 
 # ──────────── 🎵  コマンド郡 ────────────
 


### PR DESCRIPTION
## Summary
- call Cappuccino REST API when handling `/gpt` command
- decode returned images to temporary files and attach
- configure API URL via `CAPP_API_URL` env var

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687252551f64832c89f700d29d0d3f4f