### PR TITLE
Fix server app import

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Cappuccino aims to be a general‑purpose AI assistant. The project follows the 
 ## Running the server
 Start the FastAPI server with:
 ```bash
-uvicorn main:app --reload
+uvicorn api:app --reload
 ```
-This runs the minimal API defined in `main.py`.
+This runs the main API defined in `api.py`.
 
 ### Running API and Discord bot together
 To launch both the API server and the Discord bot simultaneously use

--- a/main.py
+++ b/main.py
@@ -1,17 +1,6 @@
-from fastapi import FastAPI
-from pydantic import BaseModel
+"""Backward compatibility entrypoint.
 
-app = FastAPI()
+This module simply re-exports the FastAPI `app` instance from `api.py` so that
+commands like `uvicorn main:app` continue to work."""
 
-class UserRequest(BaseModel):
-    query: str
-
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
-
-@app.post("/agent/run")
-async def run_agent(request: UserRequest):
-    # Placeholder for Cappuccino agent logic
-    return {"response": f"Processing query: {request.query}"}
-
+from api import app

--- a/run_server_bot.py
+++ b/run_server_bot.py
@@ -1,7 +1,7 @@
 import asyncio
 import uvicorn
 
-from main import app
+from api import app
 from discordbot.bot import start_bot
 
 async def start_server():


### PR DESCRIPTION
## Summary
- document running the server with `uvicorn api:app --reload`
- import `app` from `api` in `run_server_bot.py`
- keep `main.py` as compatibility wrapper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687267d9bd04832cb7bde0f030046b24