### PR TITLE
Pin httpx <0.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "fastapi",
     "python-dotenv",
     "textblob",
+    "httpx<0.28",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,5 @@ python-dotenv
 networkx
 aio_pika
 textblob
+httpx<0.28
 uvicorn


### PR DESCRIPTION
## Summary
- require `httpx<0.28` in requirements.txt
- add same constraint in pyproject

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68726a24f0b0832cbe473899107d6e2b