### PR TITLE
Add httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "fastapi",
     "python-dotenv",
     "textblob",
+    "httpx<0.28",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ networkx
 aio_pika
 textblob
 uvicorn
+httpx<0.28


### PR DESCRIPTION
## Summary
- add `httpx<0.28` to runtime requirements
- ensure pyproject lists the same dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687267da3af4832caa6b682b503fd027