### PR TITLE
Implement async speech generation

### DIFF
--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -49,7 +49,8 @@ async def test_media_generate_speech(tmp_path, monkeypatch):
 
     monkeypatch.setattr("gtts.gTTS", DummyTTS)
     result = await tm.media_generate_speech("hello", str(out_file))
-    assert "error" in result
+    assert result == {"path": str(out_file)}
+    assert out_file.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_manager_all.py
+++ b/tests/test_tool_manager_all.py
@@ -70,8 +70,19 @@ async def test_media_functions(tm, tmp_path, monkeypatch):
     img_path = tmp_path / "img.png"
     result = await tm.media_generate_image("hi", str(img_path))
     assert os.path.exists(result["path"])
-    speech = await tm.media_generate_speech("hi", "out.wav")
-    assert "error" in speech
+
+    class DummyTTS:
+        def __init__(self, text):
+            self.text = text
+        def save(self, path):
+            with open(path, "wb") as f:
+                f.write(b"data")
+
+    monkeypatch.setattr("gtts.gTTS", DummyTTS)
+    out_file = tmp_path / "speech.mp3"
+    speech = await tm.media_generate_speech("hi", str(out_file))
+    assert speech == {"path": str(out_file)}
+    assert out_file.exists()
 
     import types
     import sys

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -431,17 +431,24 @@ class ToolManager:
     async def media_generate_speech(self, text: str, output_path: str) -> Dict[str, Any]:
         """Generate speech audio from text and save as an MP3 file."""
         try:
+            output_path = self._validate_path(output_path)
+        except ValueError as e:
+            return {"error": str(e)}
+
+        try:
             from gtts import gTTS  # type: ignore
+        except Exception as e:  # pragma: no cover - import error branch
+            return {"error": str(e)}
 
-            def _generate() -> None:
-                tts = gTTS(text)
-                tts.save(output_path)
+        def _generate() -> None:
+            tts = gTTS(text)
+            tts.save(output_path)
 
+        try:
             await asyncio.to_thread(_generate)
-            # Placeholder implementation still returns an error for now
-            return {"error": "speech generation not implemented"}
-        except Exception:
-            return {"error": "speech generation not implemented"}
+            return {"path": output_path}
+        except Exception as e:
+            return {"error": str(e)}
 
 
 


### PR DESCRIPTION
## Summary
- generate speech asynchronously in `ToolManager.media_generate_speech`
- update tests to assert successful file creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b0e736c1c832c8709745074ea169f