### PR TITLE
Add image and audio tools

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -47,6 +47,34 @@ TOOLS_SCHEMA: List[Dict] = [
     {
         "type": "function",
         "function": {
+            "name": "image_classify",
+            "description": "Classify objects in an image using a lightweight model.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "image_path": {"type": "string"}
+                },
+                "required": ["image_path"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "audio_transcribe",
+            "description": "Transcribe speech from an audio file using Whisper or SpeechRecognition.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "audio_path": {"type": "string"}
+                },
+                "required": ["audio_path"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "media_describe_video",
             "description": "Return the average color of the first frame of a video.",
             "parameters": {

--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -216,3 +216,112 @@ async def test_media_describe_video(monkeypatch):
     result = await tm.media_describe_video("video.mp4")
     assert result["avg_color"] == [1.0, 2.0, 3.0]
 
+
+@pytest.mark.asyncio
+async def test_image_classify(monkeypatch):
+    tm = ToolManager(db_path=":memory:")
+
+    import types
+    import sys
+    import contextlib
+
+    class DummyInput:
+        def unsqueeze(self, dim):
+            return self
+
+    def preprocess(img):
+        return DummyInput()
+
+    class DummyModel:
+        def eval(self):
+            pass
+
+        def __call__(self, batch):
+            return [[0.2, 0.8]]
+
+    dummy_weights = types.SimpleNamespace(
+        DEFAULT=types.SimpleNamespace(
+            meta={"categories": ["cat", "dog"]},
+            transforms=lambda: preprocess,
+        )
+    )
+    models = types.SimpleNamespace(
+        mobilenet_v2=lambda weights=None: DummyModel(),
+        MobileNet_V2_Weights=dummy_weights,
+    )
+    class DummyTensor(list):
+        def argmax(self):
+            return 1
+
+    torch_mod = types.SimpleNamespace(
+        no_grad=lambda: contextlib.nullcontext(),
+        nn=types.SimpleNamespace(functional=types.SimpleNamespace(softmax=lambda x, dim=0: DummyTensor([0.2, 0.8]))),
+    )
+    torchvision_mod = types.SimpleNamespace(models=models)
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    monkeypatch.setitem(sys.modules, "torchvision", torchvision_mod)
+    monkeypatch.setitem(sys.modules, "torchvision.models", models)
+    monkeypatch.setattr("PIL.Image.open", lambda p: "img")
+
+    result = await tm.image_classify("img.png")
+    assert result["label"] == "dog"
+
+
+@pytest.mark.asyncio
+async def test_audio_transcribe_whisper(monkeypatch):
+    tm = ToolManager(db_path=":memory:")
+
+    import types
+    import sys
+
+    class DummyModel:
+        def transcribe(self, path):
+            return ([types.SimpleNamespace(text="hello ")], None)
+
+    fw_mod = types.SimpleNamespace(WhisperModel=lambda *a, **kw: DummyModel())
+    monkeypatch.setitem(sys.modules, "faster_whisper", fw_mod)
+
+    result = await tm.audio_transcribe("a.wav")
+    assert result["text"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_audio_transcribe_fallback(monkeypatch):
+    tm = ToolManager(db_path=":memory:")
+
+    import builtins
+    import types
+    import sys
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "faster_whisper":
+            raise ModuleNotFoundError
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    class DummyAudioFile:
+        def __init__(self, path):
+            self.path = path
+
+        def __enter__(self):
+            return "src"
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    class DummyRecognizer:
+        def record(self, source):
+            return b"aud"
+
+        def recognize_sphinx(self, audio):
+            return "hi"
+
+    sr_mod = types.SimpleNamespace(AudioFile=DummyAudioFile, Recognizer=DummyRecognizer)
+    monkeypatch.setitem(sys.modules, "speech_recognition", sr_mod)
+
+    result = await tm.audio_transcribe("a.wav")
+    assert result["text"] == "hi"
+

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -481,6 +481,74 @@ class ToolManager:
         return await asyncio.to_thread(_recognize)
 
     @log_tool
+    async def image_classify(self, image_path: str) -> Dict[str, Any]:
+        """Classify objects in an image using torchvision."""
+        try:
+            import torch
+            from torchvision import models
+            from torchvision.models import MobileNet_V2_Weights
+            from PIL import Image
+        except Exception:
+            return {"error": "torchvision not available"}
+
+        def _classify() -> Dict[str, Any]:
+            weights = MobileNet_V2_Weights.DEFAULT
+            model = models.mobilenet_v2(weights=weights)
+            model.eval()
+            preprocess = weights.transforms()
+            img = Image.open(image_path)
+            with torch.no_grad():
+                batch = preprocess(img).unsqueeze(0)
+                output = model(batch)[0]
+                probs = torch.nn.functional.softmax(output, dim=0)
+                idx = int(probs.argmax())
+                label = weights.meta["categories"][idx]
+                score = float(probs[idx])
+            return {"label": label, "score": score}
+
+        try:
+            return await asyncio.to_thread(_classify)
+        except Exception as e:
+            return {"error": str(e)}
+
+    @log_tool
+    async def audio_transcribe(self, audio_path: str) -> Dict[str, Any]:
+        """Transcribe speech from an audio file using Whisper or SpeechRecognition."""
+        try:
+            from faster_whisper import WhisperModel
+        except Exception:
+            WhisperModel = None  # type: ignore
+
+        if WhisperModel is not None:
+            def _whisper() -> Dict[str, Any]:
+                model = WhisperModel("tiny", device="cpu", compute_type="int8")
+                segments, _ = model.transcribe(audio_path)
+                text = "".join(seg.text for seg in segments)
+                return {"text": text.strip()}
+
+            try:
+                return await asyncio.to_thread(_whisper)
+            except Exception:
+                pass
+
+        try:
+            import speech_recognition as sr
+        except Exception:
+            return {"error": "no transcription model available"}
+
+        def _recognize() -> Dict[str, Any]:
+            recognizer = sr.Recognizer()
+            with sr.AudioFile(audio_path) as source:
+                audio = recognizer.record(source)
+            try:
+                text = recognizer.recognize_sphinx(audio)
+            except Exception:
+                return {"error": "recognition failed"}
+            return {"text": text}
+
+        return await asyncio.to_thread(_recognize)
+
+    @log_tool
     async def media_describe_video(self, video_path: str) -> Dict[str, Any]:
         """Return the average color of the first frame of a video."""
         try:


### PR DESCRIPTION
## Summary
- implement `image_classify` using torchvision
- implement `audio_transcribe` with faster-whisper fallback to SpeechRecognition
- register new tools in `TOOLS_SCHEMA`
- test image classification and audio transcription tools

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b0e751fe8832caf6f7474bcf2397e