### PR TITLE
Add task management API endpoints

### DIFF
--- a/api.py
+++ b/api.py
@@ -128,6 +128,26 @@ async def advance_plan(update: StepUpdate) -> Dict[str, Any]:
     return await state_manager.load_long_term_plan()
 
 
+class ScheduleInfo(BaseModel):
+    schedule: str
+
+
+@app.get("/agent/tasks")
+async def list_tasks() -> Dict[str, Any]:
+    """Return all tasks with phase and status."""
+    return await tool_manager.agent_list_tasks()
+
+
+@app.post("/agent/tasks/{task_id}/advance")
+async def advance_task(task_id: str) -> Dict[str, Any]:
+    return await tool_manager.agent_advance_phase(task_id)
+
+
+@app.post("/agent/tasks/{task_id}/schedule")
+async def schedule_task(task_id: str, info: ScheduleInfo) -> Dict[str, Any]:
+    return await tool_manager.agent_schedule_task(task_id, info.schedule)
+
+
 @app.post("/agent/tool_call_result")
 async def agent_tool_call_result(result: ToolCallResult) -> Dict[str, Any]:
     return await agent.handle_tool_call_result(result.data)

--- a/tests/test_task_endpoints.py
+++ b/tests/test_task_endpoints.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api
+from tool_manager import ToolManager
+from cappuccino_agent import CappuccinoAgent
+
+
+@pytest.mark.asyncio
+async def test_task_endpoints(tmp_path, monkeypatch):
+    db_path = tmp_path / "db.sqlite"
+    tm = ToolManager(db_path=str(db_path))
+    await tm.agent_update_plan("t1", "demo plan")
+
+    monkeypatch.setattr(api, "tool_manager", tm)
+    monkeypatch.setattr(api, "agent", CappuccinoAgent(tm))
+
+    client = TestClient(api.app)
+
+    resp = client.get("/agent/tasks")
+    assert resp.status_code == 200
+    tasks = resp.json()["tasks"]
+    assert tasks and tasks[0]["id"] == "t1"
+
+    resp = client.post("/agent/tasks/t1/advance")
+    assert resp.status_code == 200
+    assert resp.json()["phase"] == 1
+
+    resp = client.post("/agent/tasks/t1/schedule", json={"schedule": "daily"})
+    assert resp.status_code == 200
+    assert resp.json()["schedule"] == "daily"
+
+    await tm.close()

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -259,6 +259,20 @@ class ToolManager:
         await conn.commit()
         return {"task_id": task_id, "schedule": schedule}
 
+    @log_tool
+    async def agent_list_tasks(self) -> Dict[str, Any]:
+        """Return all tasks with phase, status and schedule."""
+        conn = await self._get_db_connection()
+        async with conn.execute(
+            "SELECT id, phase, status, schedule FROM tasks"
+        ) as cur:
+            rows = await cur.fetchall()
+        tasks = [
+            {"id": row[0], "phase": row[1], "status": row[2], "schedule": row[3]}
+            for row in rows
+        ]
+        return {"tasks": tasks}
+
     # ------------------------------------------------------------------
     # Messaging
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- support listing tasks in `ToolManager`
- expose `/agent/tasks` endpoints for task advancement and scheduling
- add test for new endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b0e757828832c9679a57b43a78524