### PR TITLE
Implement service tools

### DIFF
--- a/tests/test_service_port.py
+++ b/tests/test_service_port.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+import asyncio
+import os
+import aiohttp
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from tool_manager import ToolManager
+
+@pytest.mark.asyncio
+async def test_service_expose_port(tmp_path):
+    (tmp_path / "index.txt").write_text("hello")
+    async with ToolManager(db_path=os.path.join(tmp_path, "db.sqlite")) as tm:
+        result = await tm.service_expose_port(0, str(tmp_path))
+        port = result["port"]
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"http://localhost:{port}/index.txt") as resp:
+                text = await resp.text()
+        assert text == "hello"
+    assert tm.service_processes == {}

--- a/tests/test_tool_manager_all.py
+++ b/tests/test_tool_manager_all.py
@@ -144,17 +144,13 @@ async def test_browser_and_service_placeholders(tm):
         tm.browser_scroll_down,
         tm.browser_console_exec,
         tm.browser_console_view,
-        tm.service_expose_port,
-        tm.service_deploy_frontend,
-        tm.service_deploy_backend,
     ]
     for func in funcs:
         arg_count = func.__code__.co_argcount - 1
         if arg_count == 0:
             result = await func()
         elif arg_count == 1:
-            arg = 1 if 'service_expose_port' in func.__name__ else "x"
-            result = await func(arg)
+            result = await func("x")
         else:
             result = await func("x", "y")
         assert "error" in result

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -10,6 +10,8 @@ import tempfile
 from functools import wraps
 from typing import Any, Dict, Optional
 
+from aiohttp import web
+
 import aiosqlite
 from PIL import Image, ImageDraw
 from state_manager import StateManager
@@ -70,6 +72,17 @@ class ToolManager:
 
     async def close(self) -> None:
         """Explicitly close the database connection."""
+        for proc in list(self.service_processes.values()):
+            try:
+                if isinstance(proc, asyncio.subprocess.Process):
+                    if proc.returncode is None:
+                        proc.kill()
+                        await proc.wait()
+                else:
+                    await proc['runner'].cleanup()
+            except Exception:
+                pass
+        self.service_processes.clear()
         if self.db_connection is not None:
             await self.db_connection.close()
             self.db_connection = None
@@ -667,20 +680,61 @@ class ToolManager:
 
     @log_tool
     async def service_expose_port(self, port: int = 8000, directory: str = ".") -> Dict[str, Any]:
-        """Expose a simple HTTP service on the given port."""
-        # Placeholder implementation currently disabled for security
-        return {"error": "service management not implemented"}
+        """Expose a simple HTTP service serving files from directory."""
+        try:
+            directory = self._validate_path(directory)
+        except ValueError as e:
+            return {"error": str(e)}
+
+        app = web.Application()
+        app.router.add_static("/", directory, show_index=True)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, "0.0.0.0", port)
+        await site.start()
+        actual_port = site._server.sockets[0].getsockname()[1]
+        self.service_processes[actual_port] = {"runner": runner, "site": site}
+        return {"status": "running", "port": actual_port}
 
 
     @log_tool
 
     async def service_deploy_frontend(self, source_dir: str) -> Dict[str, Any]:
-        return {"error": "service management not implemented"}
+        try:
+            source_dir = self._validate_path(source_dir)
+        except ValueError as e:
+            return {"error": str(e)}
+
+        script = os.path.join(source_dir, "build.sh")
+        if not os.path.exists(script):
+            return {"error": "build script not found"}
+
+        process = await asyncio.create_subprocess_shell(
+            f"bash {script}", cwd=source_dir
+        )
+        self.service_processes[process.pid] = process
+        await process.wait()
+        self.service_processes.pop(process.pid, None)
+        return {"status": "completed", "returncode": process.returncode}
 
     @log_tool
     async def service_deploy_backend(self, source_dir: str) -> Dict[str, Any]:
+        try:
+            source_dir = self._validate_path(source_dir)
+        except ValueError as e:
+            return {"error": str(e)}
 
-        return {"error": "service management not implemented"}
+        script = os.path.join(source_dir, "deploy.sh")
+        if not os.path.exists(script):
+            return {"error": "deploy script not found"}
+
+        process = await asyncio.create_subprocess_shell(
+            f"bash {script}", cwd=source_dir
+        )
+        self.service_processes[process.pid] = process
+        await process.wait()
+        self.service_processes.pop(process.pid, None)
+        return {"status": "completed", "returncode": process.returncode}
 
     # ------------------------------------------------------------------
     # Slide presentation (placeholders)


### PR DESCRIPTION
## Summary
- implement `service_expose_port` using aiohttp
- add frontend/backend deploy helpers
- manage running services for cleanup
- add HTTP service test
- update existing tests

## Testing
- `pytest -q`
- `pytest tests/test_service_port.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687b0e748b84832cbe95bf89bccd794f