### PR TITLE
Implement Playwright browser automation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "python-dotenv",
     "textblob",
     "httpx<0.28",
+    "playwright",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,6 @@ networkx
 aio_pika
 textblob
 httpx<0.28
+playwright
 uvicorn
 httpx<0.28

--- a/tests/test_tool_manager_all.py
+++ b/tests/test_tool_manager_all.py
@@ -130,20 +130,8 @@ async def test_info_search(tm, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_browser_and_service_placeholders(tm):
+async def test_service_placeholders(tm):
     funcs = [
-        tm.browser_navigate,
-        tm.browser_view,
-        tm.browser_click,
-        tm.browser_input,
-        tm.browser_move_mouse,
-        tm.browser_press_key,
-        tm.browser_select_option,
-        tm.browser_save_image,
-        tm.browser_scroll_up,
-        tm.browser_scroll_down,
-        tm.browser_console_exec,
-        tm.browser_console_view,
         tm.service_expose_port,
         tm.service_deploy_frontend,
         tm.service_deploy_backend,
@@ -153,8 +141,7 @@ async def test_browser_and_service_placeholders(tm):
         if arg_count == 0:
             result = await func()
         elif arg_count == 1:
-            arg = 1 if 'service_expose_port' in func.__name__ else "x"
-            result = await func(arg)
+            result = await func("x")
         else:
             result = await func("x", "y")
         assert "error" in result

--- a/tests/test_tool_manager_browser.py
+++ b/tests/test_tool_manager_browser.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import pytest
+from tool_manager import ToolManager, BrowserHelper
+
+class DummyBrowser(BrowserHelper):
+    def __init__(self):
+        super().__init__()
+        self.content = "<button id='btn'>off</button>"
+        self.page = type("P", (), {"content": lambda s: self.content})()
+
+    async def start(self):
+        pass
+
+    async def navigate(self, url: str) -> str:
+        return self.content
+
+    async def click(self, selector: str) -> None:
+        self.content = "<button id='btn'>on</button>"
+
+    async def fill(self, selector: str, text: str) -> None:
+        self.content = f"<input id='inp' value='{text}'/>"
+
+
+@pytest.mark.asyncio
+async def test_browser_navigation_and_click(monkeypatch):
+    monkeypatch.setattr('tool_manager.BrowserHelper', DummyBrowser)
+    tm = ToolManager(db_path=':memory:')
+    await tm.browser_navigate('http://example.com')
+    assert 'off' in tm.browser_content
+    await tm.browser_click('#btn')
+    assert 'on' in tm.browser_content
+
+
+

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -46,10 +46,66 @@ def log_tool(func):
     return wrapper
 
 
+class BrowserHelper:
+    """Asynchronous helper around Playwright for basic page operations."""
+
+    def __init__(self) -> None:
+        self.playwright = None
+        self.browser = None
+        self.page = None
+        self.console: list[str] = []
+
+    async def start(self) -> None:
+        from playwright.async_api import async_playwright
+
+        self.playwright = await async_playwright().start()
+        self.browser = await self.playwright.chromium.launch(headless=True)
+        context = await self.browser.new_context()
+        self.page = await context.new_page()
+        self.page.on("console", lambda msg: self.console.append(msg.text))
+
+    async def close(self) -> None:
+        if self.browser:
+            await self.browser.close()
+        if self.playwright:
+            await self.playwright.stop()
+
+    async def navigate(self, url: str) -> str:
+        await self.page.goto(url)
+        return await self.page.content()
+
+    async def click(self, selector: str) -> None:
+        await self.page.click(selector)
+
+    async def fill(self, selector: str, text: str) -> None:
+        await self.page.fill(selector, text)
+
+    async def move_mouse(self, x: int, y: int) -> None:
+        await self.page.mouse.move(x, y)
+
+    async def press_key(self, key: str) -> None:
+        await self.page.keyboard.press(key)
+
+    async def select_option(self, selector: str, option: str) -> None:
+        await self.page.select_option(selector, option)
+
+    async def save_image(self, selector: str, output_path: str) -> None:
+        element = await self.page.query_selector(selector)
+        if not element:
+            raise ValueError("element not found")
+        await element.screenshot(path=output_path)
+
+    async def scroll_by(self, amount: int) -> None:
+        await self.page.evaluate("window.scrollBy(0, arguments[0])", amount)
+
+    async def eval_js(self, script: str):
+        return await self.page.evaluate(script)
+
+
 class ToolManager:
     """Collection of asynchronous tools for the Cappuccino agent."""
 
-    def __init__(self, db_path: str = "agent_state.db", root_dir: Optional[str] = None):
+    def __init__(self, db_path: str = "agent_state.db", root_dir: Optional[str] = None, *, browser_helper: Optional[type] = None):
         self.db_path = db_path
         self.root_dir = os.path.abspath(root_dir) if root_dir else None
         self.db_connection: Optional[aiosqlite.Connection] = None
@@ -58,6 +114,8 @@ class ToolManager:
         self.browser_url: str = ""
         self.service_processes: Dict[int, Any] = {}
         self.state_manager = StateManager(db_path)
+        self._browser_helper_cls = browser_helper or BrowserHelper
+        self.browser: Optional[BrowserHelper] = None
 
     async def __aenter__(self) -> "ToolManager":
         """Open the database connection when entering the context."""
@@ -74,6 +132,9 @@ class ToolManager:
             await self.db_connection.close()
             self.db_connection = None
         await self.state_manager.close()
+        if self.browser:
+            await self.browser.close()
+            self.browser = None
 
     # ------------------------------------------------------------------
     # Path utilities
@@ -147,6 +208,12 @@ class ToolManager:
             (name, code),
         )
         await conn.commit()
+
+    async def _get_browser(self) -> BrowserHelper:
+        if self.browser is None:
+            self.browser = self._browser_helper_cls()
+            await self.browser.start()
+        return self.browser
 
     # ------------------------------------------------------------------
     # Result caching helpers
@@ -592,27 +659,23 @@ class ToolManager:
         return {"response": data}
 
     # ------------------------------------------------------------------
-    # Browser automation (placeholders)
+    # Browser automation using Playwright
     # ------------------------------------------------------------------
     @log_tool
     async def browser_navigate(self, url: str = "") -> Dict[str, Any]:
-
-        """Fetch a web page and store its contents for later viewing."""
-        import aiohttp
+        """Navigate an embedded headless browser to the given URL."""
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url) as resp:
-                    self.browser_content = await resp.text()
-                    self.browser_url = str(resp.url)
+            browser = await self._get_browser()
+            self.browser_content = await browser.navigate(url)
+            self.browser_url = url
             return {"status": "success", "url": self.browser_url}
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - unexpected
             logging.error(f"browser_navigate error: {e}")
             return {"error": str(e)}
 
 
     @log_tool
     async def browser_view(self) -> Dict[str, Any]:
-
         """Return a preview of the last fetched page."""
         if not self.browser_content:
             return {"error": "no page loaded"}
@@ -622,44 +685,70 @@ class ToolManager:
     @log_tool
 
     async def browser_click(self, selector: str) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        browser = await self._get_browser()
+        await browser.click(selector)
+        self.browser_content = await browser.page.content()
+        return {"status": "clicked"}
 
     @log_tool
     async def browser_input(self, selector: str, text: str) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        browser = await self._get_browser()
+        await browser.fill(selector, text)
+        self.browser_content = await browser.page.content()
+        return {"status": "input"}
 
     @log_tool
     async def browser_move_mouse(self, x: int, y: int) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        browser = await self._get_browser()
+        await browser.move_mouse(x, y)
+        return {"status": "moved"}
 
     @log_tool
     async def browser_press_key(self, key: str) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        browser = await self._get_browser()
+        await browser.press_key(key)
+        self.browser_content = await browser.page.content()
+        return {"status": "pressed"}
 
     @log_tool
     async def browser_select_option(self, selector: str, option: str) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        browser = await self._get_browser()
+        await browser.select_option(selector, option)
+        self.browser_content = await browser.page.content()
+        return {"status": "selected"}
 
     @log_tool
     async def browser_save_image(self, selector: str, output_path: str) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        try:
+            browser = await self._get_browser()
+            await browser.save_image(selector, output_path)
+            return {"status": "saved", "path": output_path}
+        except Exception as e:
+            return {"error": str(e)}
 
     @log_tool
     async def browser_scroll_up(self, amount: int) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        browser = await self._get_browser()
+        await browser.scroll_by(-amount)
+        return {"status": "scrolled"}
 
     @log_tool
     async def browser_scroll_down(self, amount: int) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        browser = await self._get_browser()
+        await browser.scroll_by(amount)
+        return {"status": "scrolled"}
 
     @log_tool
     async def browser_console_exec(self, script: str) -> Dict[str, Any]:
-
-        return {"error": "browser automation not implemented"}
+        browser = await self._get_browser()
+        result = await browser.eval_js(script)
+        self.browser_content = await browser.page.content()
+        return {"result": result}
 
     @log_tool
     async def browser_console_view(self) -> Dict[str, Any]:
-        return {"error": "browser automation not implemented"}
+        browser = await self._get_browser()
+        return {"messages": browser.console}
 
     # ------------------------------------------------------------------
     # Service deployment (placeholders)


### PR DESCRIPTION
## Summary
- add Playwright dependency
- implement `BrowserHelper` with Playwright API
- wire browser methods in `ToolManager` to use Playwright
- update tests and add new browser unit tests

## Testing
- `pytest tests/test_tool_manager_browser.py tests/test_tool_manager_all.py tests/test_tool_manager.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b0e7396d0832c91a8e1496bd8d2c1