### PR TITLE
Improve logging and sync file logging/console

### DIFF
--- a/cappuccino_agent.py
+++ b/cappuccino_agent.py
@@ -14,7 +14,6 @@ from self_improver import SelfImprover
 from agents import PlannerAgent, ExecutorAgent, AnalyzerAgent
 
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
 class CappuccinoAgent:

--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -21,8 +21,8 @@ from typing import Iterable, Union, Optional
 
 # 音声読み上げや文字起こし機能は削除したため関連ライブラリは不要
 from urllib.parse import urlparse, parse_qs, urlunparse
-from logging.handlers import RotatingFileHandler
 from dotenv import load_dotenv
+from logging_config import setup_logging
 
 from dataclasses import dataclass
 from typing import Any
@@ -239,9 +239,7 @@ async def call_openai_api(
 # ───────────────── Voice Transcription / TTS ─────────────────
 
 # ───────────────── Logger ─────────────────
-handler = RotatingFileHandler('bot.log', maxBytes=1_000_000, backupCount=5, encoding='utf-8')
-logging.basicConfig(level=logging.INFO, handlers=[handler])
-logging.getLogger('discord').setLevel(logging.WARNING)
+setup_logging("bot.log")
 logger = logging.getLogger(__name__)
 
 # チャンネル型の許可タプル (Text / Thread / Stage)

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,28 @@
+import logging
+from logging.handlers import RotatingFileHandler
+
+
+def setup_logging(log_file: str = "bot.log") -> None:
+    """Configure root logger to output to console and a rotating log file."""
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        return
+
+    root_logger.setLevel(logging.INFO)
+    formatter = logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+    )
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+
+    file_handler = RotatingFileHandler(
+        log_file, maxBytes=1_000_000, backupCount=5, encoding="utf-8"
+    )
+    file_handler.setFormatter(formatter)
+
+    root_logger.addHandler(stream_handler)
+    root_logger.addHandler(file_handler)
+
+    # Reduce noise from discord library
+    logging.getLogger("discord").setLevel(logging.WARNING)

--- a/run_server_bot.py
+++ b/run_server_bot.py
@@ -3,13 +3,15 @@ import uvicorn
 
 from api import app
 from discordbot.bot import start_bot
+from logging_config import setup_logging
 
 async def start_server():
-    config = uvicorn.Config(app, host="0.0.0.0", port=8000, log_level="info")
+    config = uvicorn.Config(app, host="0.0.0.0", port=8000, log_level="info", log_config=None)
     server = uvicorn.Server(config)
     await server.serve()
 
 async def main():
+    setup_logging("bot.log")
     await asyncio.gather(start_server(), start_bot())
 
 if __name__ == "__main__":

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -24,8 +24,6 @@ class ToolExecutionError(Exception):
 
 logger = logging.getLogger(__name__)
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-
 
 def log_tool(func):
     """Decorator to log tool execution with parameters and errors."""


### PR DESCRIPTION
## Summary
- add reusable `setup_logging` helper configuring both console and file output
- call `setup_logging` in Discord bot and server startup
- rely on global logger instead of `basicConfig`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b119edcbc832c88b5a1776f00f2bf