### PR TITLE
Fix missing imports in discord bot

### DIFF
--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -26,6 +26,9 @@ import feedparser
 import json
 from cappuccino_agent import CappuccinoAgent
 from openai import AsyncOpenAI
+from PIL import Image
+import numpy as np
+import matplotlib.pyplot as plt
 from bs4 import BeautifulSoup
 from typing import Iterable, Union, Optional, Callable, Awaitable, Tuple
 from yt_dlp import YoutubeDL


### PR DESCRIPTION
## Summary
- import `Image`, `numpy`, and `matplotlib` modules in `discordbot/bot.py`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b37ff0cec832c9ff518e7df7558b7